### PR TITLE
Fix "Get .csr certificate" endpoint name

### DIFF
--- a/content-new/docs/uk-payments/confirmation-of-payee.mdx
+++ b/content-new/docs/uk-payments/confirmation-of-payee.mdx
@@ -108,7 +108,7 @@ Supporting SRD-validated CoP checks is mandatory, however the integration that i
 
 As part of your onboarding journey for CoPaaS, you will need to:
 
-- Use the [Get CSR](#get-certificate-type) endpoint to get the Certificate Signing Request (CSR) .csr file. The softwareStatementID and certificateType inputs are required. The `{softwareStatementId}` URL parameter is the unique ID of a CoP software statement on your Open Banking Directory entry.
+- Use the [Get CSR file](#get-csr-file) endpoint to get the Certificate Signing Request (CSR) .csr file. The softwareStatementID and certificateType inputs are required. The `{softwareStatementId}` URL parameter is the unique ID of a CoP software statement on your Open Banking Directory entry.
 - Use the [Create a new certificate](#create-a-new-certificate) endpoint to upload an X.509 certificate in a PEM .pem format. This is the signed PEM you can download from the Open Banking Directory after uploading the certificate signing request returned from the Get certificate type endpoint. Line breaks must be removed from the PEM before submission to ClearBank.
 
 <Callout colour="blue">
@@ -119,7 +119,7 @@ Once you have completed the onboarding set up, you can use the [CoP respond](#co
 
 <EndpointBlock
   type="get"
-  title="Get certificate type"
+  title="Get CSR file"
   endpoints={[
     {
       path: "/v1/softwarestatements/{softwareStatementId}/csr/{certificatetype}",

--- a/data/endpoints/cop-outbound-v1.json
+++ b/data/endpoints/cop-outbound-v1.json
@@ -346,12 +346,12 @@
           },
           "LegalOwnerType": {
             "type": "string",
-            "description": "Legal Owner Type used in the Cop check",
+            "description": "Legal Owner Type used in the CoP check",
             "nullable": true
           },
           "ResponderRegistrationId": {
             "type": "string",
-            "description": "Open Banking Directory registration ID of the participant responding to the cop request.",
+            "description": "Open Banking Directory registration ID of the participant responding to the CoP request.",
             "nullable": true
           }
         },


### PR DESCRIPTION
- Updated the .csr file endpoint to have the correct name
- Fixed instances of "cop" or "Cop" instead of "CoP"