### PR TITLE
Update X-Request-Id description

### DIFF
--- a/content-new/docs/api/parameters.json
+++ b/content-new/docs/api/parameters.json
@@ -23,7 +23,7 @@
     "location": "header",
     "required": true,
     "methods": ["post", "patch", "delete", "request"],
-    "body": "<p>This is what we use for idempotency and enables a duplication check. You generate this identifier which must be unique (max length 83) for any subsequent requests sent for at least 24 hours after the initial request was sent.</p><p> If an <code>X-Request-Id</code> Header is not supplied, or is invalid, a <code>400</code>:Bad Request HTTP status code response will be returned.</p><p>If ClearBank detects a duplicate, a <code>409</code>: Conflict HTTP status code response will be returned.<p>",
+    "body": "<p>This is used to check for duplicate requests. You generate this identifier which must be unique (max length 83) for any subsequent requests sent for at least 24 hours after the initial request was sent.</p><p> If an <code>X-Request-Id</code> Header is not supplied, or is invalid, a <code>400</code>:Bad Request HTTP status code response will be returned.</p><p>If ClearBank detects a duplicate, a <code>409</code>: Conflict HTTP status code response will be returned.<p>",
     "example": null
   },
   "xCorrelationId": {

--- a/content-new/docs/gbp-accounts/real-accounts.constants.tsx
+++ b/content-new/docs/gbp-accounts/real-accounts.constants.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export const postAccountsDescription = (
   <>
     <p>
-      This endpoint uses the X-Request-Id as a duplicate check and to ensure the request is idempotent.
+      This endpoint uses the X-Request-Id as a duplicate check.
     </p>
   </>
 );

--- a/content-new/docs/gbp-accounts/virtual-accounts.constants.tsx
+++ b/content-new/docs/gbp-accounts/virtual-accounts.constants.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export const postVirtualAccountsDescription = (
   <>
     <p>
-      This endpoint uses accountIdentifier as a duplicate check and to ensure the request is idempotent.
+      This endpoint uses accountIdentifier as a duplicate check.
     </p>
   </>
 );

--- a/data/endpoints/sterling-v3.json
+++ b/data/endpoints/sterling-v3.json
@@ -116,7 +116,7 @@
           "Accounts"
         ],
         "summary": "Creates an account with the specified name.",
-        "description": "Currently, this endpoint only supports the creation of current accounts.<br/>AccountName must: not be null, only white space, only contain letters, numbers and the following special characters: - ,.<br/> This endpoint uses the X-Request-Id as a duplicate check and to ensure the request is idempotent.",
+        "description": "Currently, this endpoint only supports the creation of current accounts.<br/>AccountName must: not be null, only white space, only contain letters, numbers and the following special characters: - ,.<br/> This endpoint uses the X-Request-Id as a duplicate check.",
         "operationId": "V3InstitutionsByInstitutionIdAccountsPost",
         "parameters": [
           {


### PR DESCRIPTION
Removed statement that X-Request-Id is used for idempotency. It is only used as a duplicate check.