### PR TITLE
Fixed broken links on CoP and FX Trade pages

### DIFF
--- a/content-new/docs/multi-currency/fx-trade.mdx
+++ b/content-new/docs/multi-currency/fx-trade.mdx
@@ -56,8 +56,8 @@ Additionally, you can also specify your margin (%) to be applied to the trade. T
 - Credit to the specified margin account: GBP  10
 
 **FX trades are subject to cut-off times:**
- * If a trade is booked in time for same-day settlement, you will receive a webhook notification of the settlement. If it fails to settle (in practice, because there are insufficient funds in the account), you will learn of the failure immediately. ClearBank will then send a [fx-trade-cancelled-v1](../webhooks/#fx-trade-cancelled-webhook) webhook.
- * If a trade is booked, but cannot be settled until a later day, and the settlement fails, the [fx-trade-settlement-failed-v1](../webhooks/#fx-trade-settlement-failed-webhook) webhook notifies you of the failure. Make sure you subscribe to this webhook if you are making FX trades with a value (settlement) date later than the day of booking.
+ * If a trade is booked in time for same-day settlement, you will receive a webhook notification of the settlement. If it fails to settle (in practice, because there are insufficient funds in the account), you will learn of the failure immediately. ClearBank will then send a [fx-trade-cancelled-v1](#fx-trade-cancelled-webhook) webhook.
+ * If a trade is booked, but cannot be settled until a later day, and the settlement fails, the [fx-trade-settlement-failed-v1](#fx-trade-settlement-failed-webhook) webhook notifies you of the failure. Make sure you subscribe to this webhook if you are making FX trades with a value (settlement) date later than the day of booking.
  
  For more information about cut-off times, please speak to your Relationship Manager.
 

--- a/content-new/docs/uk-payments/confirmation-of-payee.mdx
+++ b/content-new/docs/uk-payments/confirmation-of-payee.mdx
@@ -27,8 +27,8 @@ Responding to a CoP request from an external participant requires us to complete
 -	Operating nature of the account: Single or Joint
 
 For your real and virtual accounts to be CoP-ready, you will need to use the following PATCH endpoints to update your accounts:  
--	[PATCH /v1/Accounts/{accountId}](/docs/gbp-accounts/#amend-an-account-real)
--	[PATCH /v1/Accounts/{accountId}/Virtual/{virtualAccountId}](/docs/gbp-accounts/#amend-an-account-virtual)
+-	[PATCH /v1/Accounts/{accountId}](../gbp-accounts/manage-accounts#amend-an-account-real)
+-	[PATCH /v1/Accounts/{accountId}/Virtual/{virtualAccountId}](../gbp-accounts/manage-accounts#amend-an-account-virtual)
 
 If you have chosen to use the ClearBank CoP service, all your real and virtual accounts will be opted in by default, at the time of account creation. 
 


### PR DESCRIPTION
Change to documentation only; no functionality change
- Fixed links on fx-trade page to point to correct webhooks
- Fixed links on CoP page to point to correct account endpoints