### PR TITLE
Dev Portal support for displaying oneOf in payload definitions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   testEnvironment: 'jsdom',
   testMatch: ['**/**/*.spec.ts?(x)'],
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
-  transformIgnorePatterns: [`node_modules/(?!(gatsby|gatsby-script|gatsby-link|gatsby-plugin-mdx)/)`],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby|gatsby-script|gatsby-link|gatsby-plugin-mdx|element-react)/)`],
   globals: {
     NODE_ENV: 'test'
   },

--- a/src/components/endpoint-block/components/endpoint-block-content/__snapshots__/endpoint-block.spec.tsx.snap
+++ b/src/components/endpoint-block/components/endpoint-block-content/__snapshots__/endpoint-block.spec.tsx.snap
@@ -93,6 +93,9 @@ exports[`Component matches snapshot with enum array and status as a required fie
   </span>
   <p
     class="c4"
+  />
+  <p
+    class="c4"
   >
     The status of the account.
   </p>

--- a/src/components/endpoint-block/components/endpoint-block-content/endpoint-block-content.tsx
+++ b/src/components/endpoint-block/components/endpoint-block-content/endpoint-block-content.tsx
@@ -1,147 +1,257 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement } from "react"
 
-import { Collapse, CollapseItem } from 'src/components/clearbank-ui'
-import * as DataRow from 'src/components/data-row/data-row.styles'
+import { Collapse, CollapseItem } from "src/components/clearbank-ui"
+import * as DataRow from "src/components/data-row/data-row.styles"
 
-import * as Types from './endpoint-block-content.types'
+import * as Types from "./endpoint-block-content.types"
 
 const isRequired = (key: string, requiredItems: string[]) =>
-  requiredItems.some(requiredItem => requiredItem === key)
+  requiredItems.some((requiredItem) => requiredItem === key)
 
-const EndpointBlockContent: React.FunctionComponent<Types.EndpointBlockContentProps> = ({
-  allProperties,
-  requiredPropertyKeys
-}): ReactElement => {
-  // whitelisted attributes
-  const additionalAttributes = ['minimum', 'maximum', 'minLength', 'maxLength', 'pattern', 'enum']
-  const attributeNameMap = {
-    maximum: 'Maximum',
-    minimum: 'Minimum',
-    minLength: 'Minimum length',
-    maxLength: 'Maximum length',
-    pattern: 'Pattern',
-    enum: 'Enum array'
+/**
+ * Get group labels for display on-screen
+ * @param propertyName The property to be displayed
+ * @param groups The available groups defined from oneOf
+ * @returns The string to display that defines the groups
+ */
+const getOneOfGroup = (propertyName: string, groups: object) => {
+  const appearsIn = groups[propertyName]
+
+  if (!appearsIn) {
+    return ""
   }
 
-  return (
-    <>
-      {Object.keys(allProperties).map((propertyKey: string) => {
-        const currentProperty = allProperties[propertyKey]
+  return "Group: " + appearsIn.map((group: number) => group + 1).join(", ")
+}
 
-        let {
-          type,
-          description,
-          items,
-          properties,
-          required,
-          allOf
-        } = allProperties[propertyKey]
+const EndpointBlockContent: React.FunctionComponent<
+  Types.EndpointBlockContentProps
+> = ({
+  allProperties,
+  requiredPropertyKeys,
+  propertyGroups = {},
+}): ReactElement => {
+    // whitelisted attributes
+    const additionalAttributes = [
+      "minimum",
+      "maximum",
+      "minLength",
+      "maxLength",
+      "pattern",
+      "enum",
+    ]
+    const attributeNameMap = {
+      maximum: "Maximum",
+      minimum: "Minimum",
+      minLength: "Minimum length",
+      maxLength: "Maximum length",
+      pattern: "Pattern",
+      enum: "Enum array",
+    }
 
-        const hasNestedProperties = !!properties
-        const hasNestedItems = !!items && !!items.properties
-        const hasAdditionalAttributes = additionalAttributes.some(
-          additionalAttribute => additionalAttribute in currentProperty
-        )
-        let showAdditionalAttributes = false
-        // Check if schema to combine - schema can have multiple models
-        // Note, for more complex scenarios a more intelligent alogrith is required
-        const hasAnyOf = allOf && allOf.length > 0
-        let allOfSchema:any = {}
+    return (
+      <>
+        {Object.keys(allProperties).map((propertyKey: string) => {
+          const currentProperty = allProperties[propertyKey]
 
-        if (hasAnyOf) {
-          description = allOf[0].description // description is always from first key
-          // remaining schema models are merged, i.e enums. Only supports one schema
-          allOfSchema = allOf.reduce((result, current) => {
-            return Object.assign(result, current)
-          }, {})
-          type = allOfSchema.type // Layout only supports single type
-        }
+          let { type, description, items, properties, required, allOf, oneOf } =
+            allProperties[propertyKey]
 
-        if (hasAdditionalAttributes || hasAnyOf) {
-          showAdditionalAttributes = true
-        }
+          const isOneOf = oneOf && Array.isArray(oneOf) && oneOf.length > 0
 
-        return (
-          <DataRow.DataListItem key={propertyKey}>
-            <DataRow.Header className='great-primer'>
-              {propertyKey}
-            </DataRow.Header>
-            {type && (
-              <>
-                <DataRow.Type> {type}</DataRow.Type>
-              </>
-            )}
-            {requiredPropertyKeys &&
-              isRequired(propertyKey, requiredPropertyKeys) && (
+          // Merge properties and required into one object
+          if (isOneOf) {
+            required = oneOf.reduce(
+              (output: Array<Object>, choice: Types.OneOfProps) =>
+                output.concat(choice.required || []),
+              []
+            )
+            properties = oneOf.reduce(
+              (output: Array<Object>, choice: Types.OneOfProps) =>
+                Object.assign(output, choice.properties),
+              {}
+            )
+          }
+
+          const hasNestedProperties = !!properties
+          const hasNestedItems = !!items && !!items.properties
+          const hasAdditionalAttributes = additionalAttributes.some(
+            (additionalAttribute) => additionalAttribute in currentProperty
+          )
+          let showAdditionalAttributes = false
+          // Check if schema to combine - schema can have multiple models
+          // Note, for more complex scenarios a more intelligent algorithm is required
+          const hasAnyOf = allOf && allOf.length > 0
+
+          // Group properties by oneOf groups and create of a map of property to group
+          // The same name could appear in both groups so ensure there is an array
+
+          // This will be used to then seed the display with information on mutually
+          // exclusive groups. Note this doesn't currently deal with recursion i.e. a oneOf
+          // nested within a oneOf - that needs some thought
+          const oneOfPropertyGroups: object = (isOneOf ? oneOf : []).reduce(
+            (output: object, choice: Types.OneOfProps, index: number) => {
+              if (choice.properties) {
+                Object.keys(choice.properties).forEach((prop) => {
+                  output[prop] = (output[prop] || []).concat([index])
+                })
+              }
+
+              return output
+            },
+            {}
+          )
+
+          let parentObjectGuidance = isOneOf
+            ? oneOf.length < 2
+              ? ""
+              : oneOf.reduce(
+                (output: string, choice: Types.OneOfProps, index: number) => {
+                  const choicePropertyNames = Object.keys(choice.properties || [])
+
+                  if (choicePropertyNames.length === 0) {
+                    return output + " the value of the property with the type " + choice.type
+                  }
+
+                  const requirementDescription = choicePropertyNames
+                    .map((propertyName, index) => {
+                      if (index !== 0 && index === choicePropertyNames.length - 1) {
+                        return ", and " + propertyName
+                      }
+
+                      if (index !== 0 && index === choicePropertyNames.length - 2) {
+                        return ", " + propertyName
+                      }
+
+                      return propertyName
+                    })
+
+                  if (index === 0) {
+                    return (output + requirementDescription.join(""))
+                  }
+
+                  if (index !== oneOf.length - 1) {
+                    return output + ", " + requirementDescription.join("")
+                  }
+
+                  return (output + " OR " + requirementDescription.join("") + " as shown in the groups below.")
+                },
+                " You need to include EITHER "
+              )
+            : ""
+
+          let allOfSchema: any = {}
+
+          if (hasAnyOf) {
+            description = allOf[0].description // description is always from first key
+            // remaining schema models are merged, i.e enums. Only supports one schema
+            allOfSchema = allOf.reduce(
+              (result: Array<string>, current: Object) => {
+                return Object.assign(result, current)
+              },
+              {}
+            )
+            type = allOfSchema.type // Layout only supports single type
+          }
+
+          if (hasAdditionalAttributes || hasAnyOf || isOneOf) {
+            showAdditionalAttributes = true
+          }
+
+          return (
+            <DataRow.DataListItem key={propertyKey}>
+              <DataRow.Header className="great-primer">
+                {propertyKey}
+              </DataRow.Header>
+              {type && (
                 <>
-                  {type && <>,{'  '}</>}
-                  <DataRow.Required>Required</DataRow.Required>
+                  <DataRow.Type> {type}</DataRow.Type>
                 </>
               )}
-            {/* new line */}
-            {description && (
-              <>
-                <DataRow.Description>{description}</DataRow.Description>
-              </>
-            )}
-            {showAdditionalAttributes &&
-              additionalAttributes.map(additionalAttribute => {
-                const targetAttributes = hasAnyOf ? allOfSchema : currentProperty
-                const hasAttributeFromList =
-                  additionalAttribute in targetAttributes
+              {requiredPropertyKeys &&
+                isRequired(propertyKey, requiredPropertyKeys) && (
+                  <>
+                    {type && <>,{"  "}</>}
+                    <DataRow.Required>Required</DataRow.Required>
+                  </>
+                )}
+              {/* new line */}
+              {
+                <>
+                  <DataRow.Description>
+                    {getOneOfGroup(propertyKey, propertyGroups)}
+                  </DataRow.Description>
+                </>
+              }
+              {description && (
+                <>
+                  <DataRow.Description>
+                    {description + parentObjectGuidance}
+                  </DataRow.Description>
+                </>
+              )}
+              {showAdditionalAttributes &&
+                additionalAttributes.map((additionalAttribute) => {
+                  const targetAttributes = hasAnyOf
+                    ? allOfSchema
+                    : currentProperty
+                  const hasAttributeFromList =
+                    additionalAttribute in targetAttributes
 
-                if (!hasAttributeFromList) {
-                  return null
-                }
+                  if (!hasAttributeFromList) {
+                    return null
+                  }
 
-                const attributeKey =
-                  additionalAttribute in attributeNameMap
-                    ? attributeNameMap[additionalAttribute]
-                    : additionalAttribute // fallback
-                const attributeValue = targetAttributes[additionalAttribute]
-                const isComplexType = Array.isArray(attributeValue)
+                  const attributeKey =
+                    additionalAttribute in attributeNameMap
+                      ? attributeNameMap[additionalAttribute]
+                      : additionalAttribute // fallback
+                  const attributeValue = targetAttributes[additionalAttribute]
+                  const isComplexType = Array.isArray(attributeValue)
 
-                return (
-                  <DataRow.AdditionalAttributesList key={additionalAttribute}>
-                    <DataRow.AdditionalAttributeKey>
-                      {attributeKey}
-                    </DataRow.AdditionalAttributeKey>
-                    <DataRow.AdditionalAttributeValue
-                      isComplexType={isComplexType}
-                    >
-                      {isComplexType
-                        ? attributeValue.join(', ')
-                        : attributeValue}
-                    </DataRow.AdditionalAttributeValue>
-                  </DataRow.AdditionalAttributesList>
-                )
-              })}
+                  return (
+                    <DataRow.AdditionalAttributesList key={additionalAttribute}>
+                      <DataRow.AdditionalAttributeKey>
+                        {attributeKey}
+                      </DataRow.AdditionalAttributeKey>
+                      <DataRow.AdditionalAttributeValue
+                        isComplexType={isComplexType}
+                      >
+                        {isComplexType
+                          ? attributeValue.join(", ")
+                          : attributeValue}
+                      </DataRow.AdditionalAttributeValue>
+                    </DataRow.AdditionalAttributesList>
+                  )
+                })}
 
-            {(hasNestedProperties || hasNestedItems) && (
-              <DataRow.DataList nested>
-                <Collapse>
-                  <CollapseItem title='Show children' nested>
-                    {hasNestedProperties && (
-                      <EndpointBlockContent
-                        allProperties={properties}
-                        requiredPropertyKeys={required}
-                      />
-                    )}
-                    {hasNestedItems && (
-                      <EndpointBlockContent
-                        allProperties={items.properties}
-                        requiredPropertyKeys={items.required}
-                      />
-                    )}
-                  </CollapseItem>
-                </Collapse>
-              </DataRow.DataList>
-            )}
-          </DataRow.DataListItem>
-        )
-      })}
-    </>
-  )
-}
+              {(hasNestedProperties || hasNestedItems) && (
+                <DataRow.DataList nested>
+                  <Collapse>
+                    <CollapseItem title="Show children" nested>
+                      {hasNestedProperties && (
+                        <EndpointBlockContent
+                          allProperties={properties}
+                          requiredPropertyKeys={required}
+                          propertyGroups={oneOfPropertyGroups}
+                        />
+                      )}
+                      {hasNestedItems && (
+                        <EndpointBlockContent
+                          allProperties={items.properties}
+                          requiredPropertyKeys={items.required}
+                          propertyGroups={oneOfPropertyGroups}
+                        />
+                      )}
+                    </CollapseItem>
+                  </Collapse>
+                </DataRow.DataList>
+              )}
+            </DataRow.DataListItem>
+          )
+        })}
+      </>
+    )
+  }
 
 export default EndpointBlockContent

--- a/src/components/endpoint-block/components/endpoint-block-content/endpoint-block-content.types.ts
+++ b/src/components/endpoint-block/components/endpoint-block-content/endpoint-block-content.types.ts
@@ -1,4 +1,11 @@
 export interface EndpointBlockContentProps {
   allProperties: any
   requiredPropertyKeys: any
+  propertyGroups?: object
+}
+
+export interface OneOfProps {
+  type: string,
+  required: Array<string>,
+  properties: Object,
 }

--- a/src/components/endpoint-block/components/endpoint-block-content/endpoint-block.spec.tsx
+++ b/src/components/endpoint-block/components/endpoint-block-content/endpoint-block.spec.tsx
@@ -11,7 +11,58 @@ let component: ReturnType<typeof render> = null
 let fragment: DocumentFragment = null
 let root: HTMLElement = null
 
-const allProperties:any = {"status":{"description":"The status of the account.","enum":["NotProvided","Enabled","Closed","Suspended"],"type":"string"},"statusReason":{"description":"The account status reason","enum":["NotProvided","AccountHolderBankrupt","AccountHolderDeceased","AccountSwitched","CompanyNoLongerTrading","DissatisfiedCustomer","DuplicateSoleTraderAccount","FinancialCrime","FraudFirstParty","FraudThirdParty","Other"],"type":"string"}}
+const allProperties: any = {
+  "status": {
+    "description": "The status of the account.",
+    "enum": ["NotProvided", "Enabled", "Closed", "Suspended"],
+    "type": "string"
+  },
+  "statusReason": {
+    "description": "The account status reason",
+    "enum": ["NotProvided", "AccountHolderBankrupt", "AccountHolderDeceased", "AccountSwitched", "CompanyNoLongerTrading", "DissatisfiedCustomer", "DuplicateSoleTraderAccount", "FinancialCrime", "FraudFirstParty", "FraudThirdParty", "Other"],
+    "type": "string"
+  },
+  "sourceAccount": {
+    "oneOf": [
+      {
+        "type": "string"
+      },
+      {
+        "type": "object",
+        "required": ["iban"],
+        "properties": {
+          "iban": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
+          }
+        },
+        "additionalProperties": false
+      },
+      {
+        "type": "object",
+        "required": ["schemeName", "identification"],
+        "properties": {
+          "schemeName": {
+            "type": "string",
+            "enum": ["BBan", "Other"],
+            "example": "Other"
+          },
+          "proprietary": {
+            "type": "string",
+            "enum": ["SortcodeAccountNumber"],
+          },
+          "identification": {
+            "type": "string",
+            "minLength": 1,
+            "example": "01020301234567"
+          }
+        },
+        "additionalProperties": false
+      }
+    ]
+  }
+}
 
 const defaultProps: Types.EndpointBlockContentProps = {
   allProperties,

--- a/src/components/endpoint-block/components/endpoint-block-model/endpoint-block-model.tsx
+++ b/src/components/endpoint-block/components/endpoint-block-model/endpoint-block-model.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from 'react'
+import React, { ReactElement } from "react"
 
-import Codeblock from 'src/components/codeblock'
-import * as DataRow from 'src/components/data-row/data-row.styles'
-import { CodeblockType } from 'src/global.types'
+import Codeblock from "src/components/codeblock"
+import * as DataRow from "src/components/data-row/data-row.styles"
+import { CodeblockType } from "src/global.types"
 
-import EndpointBlockContent from '../endpoint-block-content'
+import EndpointBlockContent from "../endpoint-block-content"
 
-import * as Styles from './endpoint-block-model.styles'
-import * as Types from './endpoint-block-model.types'
+import * as Styles from "./endpoint-block-model.styles"
+import * as Types from "./endpoint-block-model.types"
 
 const getInitialProperties = (apiData: any, path: string, type: string) => {
   const { requestBody } = apiData.paths[path][type]
@@ -16,19 +16,15 @@ const getInitialProperties = (apiData: any, path: string, type: string) => {
     return [false, false]
   }
 
-  const { properties, required } = requestBody.content[
-    'application/json'
-  ].schema
+  const { properties, required } =
+    requestBody.content["application/json"].schema
 
   return [properties, required]
 }
 
-const EndpointBlockModel: React.FunctionComponent<Types.EndpointBlockModelProps> = ({
-  path,
-  type,
-  apiData,
-  codeblocks
-}): ReactElement => {
+const EndpointBlockModel: React.FunctionComponent<
+  Types.EndpointBlockModelProps
+> = ({ path, type, apiData, codeblocks }): ReactElement => {
   const [initialProperties, initialRequiredProperties] = getInitialProperties(
     apiData,
     path,
@@ -40,8 +36,8 @@ const EndpointBlockModel: React.FunctionComponent<Types.EndpointBlockModelProps>
   return (
     <>
       <Styles.Header>
-        <DataRow.BlockTitle as='h4' className='double-pica'>
-          Request Payload{' '}
+        <DataRow.BlockTitle as="h4" className="double-pica">
+          Request Payload{" "}
           <DataRow.LighterText>(application/json)</DataRow.LighterText>
         </DataRow.BlockTitle>
       </Styles.Header>


### PR DESCRIPTION
Add support for displaying OneOf construct in endpoint definitions on the Developer Portal. No change to documentation or API functionality.

* feat: Add support for oneOf in generating description and labels

* chore: Updated snapshot and added Oxford comma

* feat: Added support for oneOf in schema object display

---------