### PR TITLE
Camt.053 statement page size amendment

### DIFF
--- a/content-new/docs/gbp-accounts/account-reporting.mdx
+++ b/content-new/docs/gbp-accounts/account-reporting.mdx
@@ -33,7 +33,7 @@ The process is shown in this message flow diagram:
 
 <br />
 
-Once the statement has been generated, you will receive a **Statements Ready For Download** webhook containing a unique **MessageId** and a **TotalPages** value. The statement is divided into pages and each page is assigned a **PageNumber** value. If a page reaches the maximum number of accounts (5000), the statement is continued on a new page. Each page is a complete XML file starting with a group header. 
+Once the statement has been generated, you will receive a **Statements Ready For Download** webhook containing a unique **MessageId** and a **TotalPages** value. The statement is divided into pages and each page is assigned a **PageNumber** value. If a page reaches the maximum number of transactions (5000), the statement is continued on a new page. Each page is a complete XML file starting with a group header. 
 
 <Callout colour="blue">
 The time taken to generate a statement varies depending on the number of accounts and number of settled transactions on it. 

--- a/content-new/docs/gbp-accounts/account-reporting.mdx
+++ b/content-new/docs/gbp-accounts/account-reporting.mdx
@@ -36,7 +36,7 @@ The process is shown in this message flow diagram:
 Once the statement has been generated, you will receive a **Statements Ready For Download** webhook containing a unique **MessageId** and a **TotalPages** value. The statement is divided into pages and each page is assigned a **PageNumber** value. If a page reaches the maximum number of transactions (5000), the statement is continued on a new page. Each page is a complete XML file starting with a group header. 
 
 <Callout colour="blue">
-The time taken to generate a statement varies depending on the number of accounts and number of settled transactions on it. 
+The time taken to generate a statement varies depending on the number of settled transactions included in the request. 
 Once generated, statements are retained for 2 weeks.
 </Callout>
 


### PR DESCRIPTION
- Maximum page size of a camt.053 statement amended from 5000 accounts per page to 5000 transactions per page.