### PR TITLE
Transaction Settled webhook scheme field, and fix broken links

### DIFF
--- a/content-new/docs/api/getting-started.mdx
+++ b/content-new/docs/api/getting-started.mdx
@@ -139,7 +139,7 @@ The response shows results from the test call
 ```
 
 To confirm that authentication and signature verification are working as expected, when you send a POST/v1/Test request you will receive a `FITestEvent webhook` from ClearBank (if you are subscribed to it).
-We use webhooks to deliver transaction confirmation notifications and account-specific reconciliations to your system as soon as such events occur on your account. Please refer to [Test Webhooks](/webhooks/) for more information.
+We use webhooks to deliver transaction confirmation notifications and account-specific reconciliations to your system as soon as such events occur on your account. Please refer to [Set up and test webhook listener URLs](#set-up-and-test-webhook-listener-urls) for more information.
 
 <EndpointBlock
   type="get"

--- a/content-new/docs/uk-payments/bacs-direct-debit-instructions.mdx
+++ b/content-new/docs/uk-payments/bacs-direct-debit-instructions.mdx
@@ -17,16 +17,16 @@ A DDI can be submitted to ClearBank by service users in two ways:
 - Electronically via the Bacs Automated Direct Debit Instruction Service (AUDDIS), or,
 - Sent as a paper instruction to your address to be entered via the ClearBank API after you have validated it.
 
-A DDI can be set up against a real or virtual account held with ClearBank. It cannot be set up against a General Segregated Account, your Bacs Suspense Account, or your Minimum Mandated Balance account. You will receive the [Bacs Mandate Initiated webhook](./webhooks/#bacs-mandate-initiated-webhook) once the DDI is present in our system.
+A DDI can be set up against a real or virtual account held with ClearBank. It cannot be set up against a General Segregated Account, your Bacs Suspense Account, or your Minimum Mandated Balance account. You will receive the [Bacs Mandate Initiated webhook](#bacs-mandate-initiated-webhook) once the DDI is present in our system.
 
 If you are transferring an existing sort code to ClearBank that already has DDIs set up, you will need to use the API to inform us of these.
 
 Once a DDI has been set up against an account via AUDDIS, payments may be collected from the account from the third day; for paper instructions, payments may be collected from the following day.
 The timing of the payment is in the control of the service user and does not necessarily follow immediately.
 
-To receive feedback during DDI management, subscribe to the relevant webhooks which are listed here: [BACS DDI webhooks](./webhooks/#bacs-direct-debit-instructions).
+To receive feedback during DDI management, subscribe to the relevant webhooks which are listed here: [BACS DDI webhooks](#bacs-ddi-webhooks).
 
-**Note**: Occasionally you might receive a [Bacs Mandate Cancellation Failed webhook](./webhooks/#bacs-mandate-cancellation-failed-webhook), after having cancelled a Direct Debit Instruction through the `DELETE` endpoints.  This does not necessarily mean a real failure. This situation can arise as in the following example:<br/>
+**Note**: Occasionally you might receive a [Bacs Mandate Cancellation Failed webhook](#bacs-mandate-cancellation-failed-webhook), after having cancelled a Direct Debit Instruction through the `DELETE` endpoints.  This does not necessarily mean a real failure. This situation can arise as in the following example:<br/>
 
 An end-customer cancels their phone contract with "FabuPhone". FabuPhone immediately cancel the DDI through the Bacs system. The end-customer also requests that you cancel the DDI, and you attempt to do so using the `DELETE` endpoint. As the instruction was already cancelled, it no longer exists and cannot be found. You will then receive a Bacs Mandate Cancellation Failed webhook.<br/> 
 You can use the `GET endpoint (GET /{vn}/Accounts/{accountId}/Mandates)` to check the DDIs in place for the account and verify that everything is as it should be.

--- a/content-new/docs/uk-payments/bacs-direct-debit-instructions.mdx
+++ b/content-new/docs/uk-payments/bacs-direct-debit-instructions.mdx
@@ -161,37 +161,11 @@ If a Direct Debit is cancelled due to dormancy but is still required, the servic
 
 The following webhooks relate to managing Direct Debit Instructions. The webhooks can occur in response to an endpoint (as detailed below) but also if we receive a DDI from the Bacs payment service. The webhooks returned are the same regardless of whether a real or virtual account endpoint is used. Note that the webhook names include the term "mandate". This reflects the code, but should be understood to mean "Direct Debit Instruction".
 
-<WebhookSummary
-  description='Create a DDI for a real account'
-  endpoint='/bacs-direct-debits/#create-ddi-for-a-real-account'
-  method='post'
-  webhooks={[
-    'bacs-mandate-initiated-webhook-v2',
-    'bacs-mandate-initiation-failed-webhook-v1'
-  ]}
-/>
-
-
-<WebhookSummary
-  description='Cancel a DDI for a real or virtual account'
-  endpoint='/bacs-direct-debits/#cancel-a-ddi-for-a-real-account'
-  method='delete'
-  webhooks={[
-    'bacs-mandate-cancelled-webhook-v2',
-    'bacs-mandate-cancellation-failed-webhook-v1'
-  ]}
-/>
-
-
-<WebhookSummary
-  description='Return a DDI for an account'
-  endpoint='/bacs-direct-debits/#return-ddi-for-an-account'
-  method='post'
-  webhooks={[
-    'bacs-mandate-returned-webhook-v1',
-    'bacs-mandate-return-failed-webhook-v1'
-  ]}
-/>
+| Event | Associated webhooks |
+|---------|------------|
+| [Create a DDI for a real account](#create-a-ddi-real-account) OR [Create a DDI for a virtual account](#create-a-ddi-virtual-account) | <ul><li>[Bacs Mandate Initiated webhook](#bacs-mandate-initiated-webhook)</li> <li>[Bacs Mandate Initiation Failed webhook](#bacs-mandate-initiation-failed-webhook)</li></ul> |
+| [Cancel a DDI for a real account](#cancel-a-ddi-real-account) OR [Cancel a DDI for a virtual account](#cancel-a-ddi-virtual-account) | <ul><li>[Bacs Mandate Cancelled webhook](#bacs-mandate-cancelled-webhook)</li> <li>[Bacs Mandate Cancellation Failed webhook](#bacs-mandate-cancellation-failed-webhook)</li></ul> |
+| [Return a DDI for a real account](#return-a-ddi-real-account) OR [Return a DDI for a virtual account](#return-a-ddi-virtual-account) | <ul><li>[Bacs Mandate Returned webhook](#bacs-mandate-returned-webhook)</li> <li>[Bacs Mandate Return Failed webhook](#bacs-mandate-return-failed-webhook)</li></ul> |
 
 You may also receive a [Bacs Mandate Migrated webhook](#bacs-mandate-migrated-webhook) which is prompted by information received from Bacs.
 

--- a/content-new/docs/uk-payments/bacs.mdx
+++ b/content-new/docs/uk-payments/bacs.mdx
@@ -20,23 +20,23 @@ When a payment is successfully applied to an account, this message flow occurs:
 
 ![Image showing a successful Bacs payment](/assets/images/BacsOverview-PaymentSuccess.svg "Successful Bacs payment")
 
-If you subscribe to the [Bacs Direct Debit Inbound Payment Created](../webhooks/#bacs-direct-debit-inbound-payment-created-webhook) and [Bacs Direct Credit Inbound Payment Created](../webhooks/#bacs-direct-credit-inbound-payment-created-webhook) webhooks, then you can use the information to notify the account owner of a pending payment scheduled to occur on day 3. You can use the Bacs transaction ID to associate the webhooks that describe each payment. Note that credit payments can be recalled up to 4pm on the processing day by the originator; in this case you will be notified by a [Bacs Direct Credit Recalled webhook](../webhooks/#bacs-direct-credit-recalled-webhook) and the credit will not appear in the account.
+If you subscribe to the [Bacs Direct Debit Inbound Payment Created](#bacs-direct-debit-inbound-payment-created-webhook) and [Bacs Direct Credit Inbound Payment Created](#bacs-direct-credit-inbound-payment-created-webhook) webhooks, then you can use the information to notify the account owner of a pending payment scheduled to occur on day 3. You can use the Bacs transaction ID to associate the webhooks that describe each payment. Note that credit payments can be recalled up to 4pm on the processing day by the originator; in this case you will be notified by a [Bacs Direct Credit Recalled webhook](#bacs-direct-credit-recalled-webhook) and the credit will not appear in the account.
 
 Whether a payment is successfully applied to the end-customer's account is determined like this:
 
 ![Image showing a Inbound Bacs decision tree](/assets/images/BacsOverview-DecisionTree.svg "Inbound Bacs decision tree")
 
-If the payment cannot be applied to the account, ClearBank will automatically raise an ARUCS (Automated Return of Unapplied Credits Service) item  or an ARUDD (Automated Return of Unpaid Direct Debit) item. You will be notified with a [Bacs Direct Credit Return Created](../webhooks/#bacs-direct-credit-return-created-webhook) or [Bacs Direct Debit Return Created](../webhooks/#bacs-direct-debit-return-created-webhook) webhook. Note that if a Direct Debit is paid from a virtual account, it is your responsibility to ensure that the account has sufficient funds. If it does not, use the returns endpoints below.
+If the payment cannot be applied to the account, ClearBank will automatically raise an ARUCS (Automated Return of Unapplied Credits Service) item  or an ARUDD (Automated Return of Unpaid Direct Debit) item. You will be notified with a [Bacs Direct Credit Return Created](#bacs-direct-credit-return-created-webhook) or [Bacs Direct Debit Return Created](#bacs-direct-debit-return-created-webhook) webhook. Note that if a Direct Debit is paid from a virtual account, it is your responsibility to ensure that the account has sufficient funds. If it does not, use the returns endpoints below.
 
 ## Returning a Bacs payment
 
 You can choose to return a payment that has been applied. Returns should be initiated straight away, but can be initiated until 15:30 (UTC) the working day after settlement.
 
-**To return a Direct Credit** use the endpoints below and specify the reason for return using a [Direct Credit reason code](#arucs-direct-credit-reason-codes). ClearBank will notify you with a [Bacs Direct Credit Return Created webhook](../webhooks/#bacs-direct-credit-return-created-webhook) on the day the return is created (Day 3 or 4).  The funds will be transferred to your Bacs suspense account on the same day and returned on Day 5 or 6. The message flow is shown here:
+**To return a Direct Credit** use the endpoints below and specify the reason for return using a [Direct Credit reason code](#arucs-direct-credit-reason-codes). ClearBank will notify you with a [Bacs Direct Credit Return Created webhook](#bacs-direct-credit-return-created-webhook) on the day the return is created (Day 3 or 4).  The funds will be transferred to your Bacs suspense account on the same day and returned on Day 5 or 6. The message flow is shown here:
 
 ![Image showing a Inbound Bacs decision tree](/assets/images/BacsOverview-ReturnsDC.svg "Message flow: Return a Direct Credit")
 
-**To return a Direct Debit** use the endpoints below and specify the reason for return using a [Direct Debit reason code](#arudd-direct-debit-reason-codes). ClearBank will notify you with a [Bacs Direct Debit Return Created webhook](../webhooks/#bacs-direct-debit-return-created-webhook) on the day the return is created (Day 3 or 4). The funds will be transferred from your Bacs suspense account to the end-customer's account on the same day and returned on Day 5 or 6. The rest of the message flow is similar to returning a Direct Credit and is shown here:
+**To return a Direct Debit** use the endpoints below and specify the reason for return using a [Direct Debit reason code](#arudd-direct-debit-reason-codes). ClearBank will notify you with a [Bacs Direct Debit Return Created webhook](#bacs-direct-debit-return-created-webhook) on the day the return is created (Day 3 or 4). The funds will be transferred from your Bacs suspense account to the end-customer's account on the same day and returned on Day 5 or 6. The rest of the message flow is similar to returning a Direct Credit and is shown here:
 
 ![Image showing a Inbound Bacs decision tree](/assets/images/BacsOverview-ReturnsDD.svg "Message flow: Return a Direct Debit")
 

--- a/webhooks/transaction-rejected-v2.mdx
+++ b/webhooks/transaction-rejected-v2.mdx
@@ -22,7 +22,7 @@ This webhook confirms the payment has been rejected.
 |-------------------------|-----------------|
 | `TransactionId`         | Unique Identification of the Transaction.<br /> Type: `GUID` <br /> Max. Length: `36`<br /> Special Character: Hyphen `-`<br /> Example format of a typical TransactionId:`073dca79-13b8-8bf2-b63b-148957caffe9` |
 | `Status`                | Transaction status.<br />Type: `string`<br />`Rejected` |
-| `Scheme`                | *Optional* <br />The Scheme type.<br /> `Transfer`,<br />`FasterPayments`,<br />`Bacs`,<br />`Chaps`  |
+| `Scheme`                | *Optional* <br />The Scheme type.<br /> `Transfer`,<br />`FasterPayments`,<br />`Chaps`  |
 | `EndToEndTransactionId` | Unique Identifier supplied by you in your API request. For inbound transactions, this identifier may not be unique.<br />Type: `string`<br />Max. length:`35` |
 | `Amount`                | Transaction amount. <br />Type: `number`<br/> Format: `decimal` |
 | `TimestampModified`     | Date and time the transaction was rejected.<br /> Time Zone: `UTC`<br /> Type: `DateTime` |


### PR DESCRIPTION
Update to documentation only; no change to functionality.

- Removed `Bacs` as a `Scheme` field return from Transaction Settled webhook as it can never be returned
- Fixed broken links on Bacs and Bacs DDI Instruction pages and on Getting Started page
- Updated Bacs DDI webhooks section table