### PR TITLE
GitHub edit link fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -31,7 +31,7 @@ const config = {
     title: 'ClearBank Developer Portal',
     description: 'ClearBank Developer Portal - our API documentation',
     ogImage: null,
-    docsLocation: 'https://github.com/clearbank/docs/tree/master/content/docs',
+    docsLocation: 'https://github.com/clearbank/clearbank.github.io/tree/main/content',
     favicon: '/assets/images/favicon-32x32.png'
   },
   pwa: {

--- a/config.js
+++ b/config.js
@@ -9,7 +9,7 @@ const config = {
     logoLink: '/',
     title: 'ClearBank Developer Portal',
     githubUrl: 'https://github.com/clearbank/',
-    githubDocsRoot: 'https://github.com/clearbank/docs/blob/master/content',
+    githubDocsRoot: 'https://github.com/clearbank/clearbank.github.io/tree/main/content',
     helpUrl: '',
     tweetText: '',
     links: [{ text: '', link: '' }],


### PR DESCRIPTION
Infra change, no docs changes.
* We were referencing the old docs GitHub site instead of this one.
* This PR fixes the GitHub links by updating the reference values in the `config.js` file

![{57992446-AF96-4061-A799-2826B5D64A12}](https://github.com/user-attachments/assets/20ab59f4-23d1-42f0-a9d7-a84731ce068e)
