### PR TITLE
Fix: EU virtual account documentation 

### DIFF
--- a/content/eu/docs/accounts/manage-virtual-accounts.mdx
+++ b/content/eu/docs/accounts/manage-virtual-accounts.mdx
@@ -14,7 +14,7 @@ import Callout from "src/components/callout";
 
 Virtual accounts are publicly addressable accounts with their own IBAN. Also known as shadow accounts, virtual accounts are linked to real accounts and are used to separate out funds held in real accounts for the purposes of improved reconciliation and liquidity management. The responsibility of managing and reconciling virtual accounts rests with you, giving you complete control of such accounts.
 
-Virtual accounts are only compatible with General Segregated Accounts and General Client Accounts, and can be created, suspended or activated, and closed via our API. 
+Virtual accounts are only compatible with General Segregated Accounts. Virtual accounts can be created, suspended or activated, and closed via our API. 
 
 To comply with the Funds Transfer Regulation, it is important that the naming of virtual accounts reflects the legal name of the customer.
 


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Removed incorrect statement that Virtual Accounts were compatible with General Client Accounts in Europe.