### PR TITLE
T2 now fully live

### DIFF
--- a/content/eu/docs/api/support-life-cycle.mdx
+++ b/content/eu/docs/api/support-life-cycle.mdx
@@ -8,9 +8,6 @@ import Callout from "src/components/callout";
 
 ## Support life cycle
 
-<Callout colour="green"><h2>Our API for Europe is coming soon</h2><p>All information on this page describes a solution that is <strong>not yet live in production and therefore could change</strong>. This includes any endpoint and webhook details. The information is being provided early to aid you in integrating with our API in our European simulation environment.</p>
-</Callout>
-
 All endpoints and webhooks released by ClearBank will be supported for a minimum of 12 months before these are reviewed for withdrawal.
 
 Following the initial 12-month period, all endpoints and webhooks will be reviewed every 6 months. This review will allow us to decide whether an endpoint or webhook should be withdrawn.

--- a/content/eu/docs/api/versioning.mdx
+++ b/content/eu/docs/api/versioning.mdx
@@ -4,14 +4,9 @@ order: 3
 showPageMenu: true
 ---
 
-
 import Callout from "src/components/callout";
 
-
 ## Versioning
-
-<Callout colour="green"><h2>Our API for Europe is coming soon</h2><p>All information on this page describes a solution that is <strong>not yet live in production and therefore could change</strong>. This includes any endpoint and webhook details. The information is being provided early to aid you in integrating with our API in our European simulation environment.</p>
-</Callout>
 
 Providing developers with a seamless integration experience is at the core of our API versioning approach. We work in an agile environment and iteratively release the latest versions of individual endpoints and webhooks.
 

--- a/content/eu/docs/eur-payments/t2.mdx
+++ b/content/eu/docs/eur-payments/t2.mdx
@@ -11,9 +11,6 @@ import Callout from "src/components/callout"
 
 ## T2
 
-<Callout colour="green"><h2>T2 is coming soon</h2><p>All information on this page describes a solution that is <strong>not yet live in production and therefore could change</strong>. This includes any endpoint and webhook details. The information is being provided early to aid you in integrating with our API in our European simulation environment.</p>
-</Callout>
-
 T2, formerly known as TARGET2, is the Real Time Gross Settlement payment scheme for euro payments. It uses ISO 20022 message formats.
 
 T2 has no transaction limit, making it suitable for high-value payments. Transactions are processed in euros using central bank money. When you submit a payment, we send a settlement request to the RTGS system. This processes the request and, upon approval, debits ClearBank and credits the recipient bank. It also sends a settlement confirmation.


### PR DESCRIPTION
Removed caveat from T2 page, versioning, and support life cycle pages as T2 is now out of live proving.