### PR TITLE
Cheques webhook documentation fixes

### DIFF
--- a/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
+++ b/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
@@ -24,13 +24,12 @@ The balance of a cash ISA is held by ClearBank and can only be viewed via our AP
 Funds can be transferred in from either the nominated account or another ClearBank account held by your organisation. Name matching between ClearBank accounts is your responsibility.
 </Callout>
 
-Because cash ISAs are structured differently to other account types, you will need to use the endpoints defined on this page to interact with them. Do not use the endpoints listed on the [Manage sterling acounts page](./manage-accounts).
+Because cash ISAs are structured differently to other account types, you will need to use the endpoints defined on this page to interact with them. Do not use the endpoints listed on the [Manage sterling acounts page](/uk/docs/gbp-accounts/manage-accounts).
 
 The sections below explain how to:
 - [Set up a cash ISA](#set-up-a-cash-isa)
 - [Close, cancel, or discontinue a cash ISA](#end-of-life-for-a-cash-isa)
-- [Set a customer's cash ISA eligibility](#setting-customer-eligibility)
-- [Transfer in a cash ISA](#transfers-in)
+- [Transfer in a cash ISA](#transfer-in)
 - [Transfer out a cash ISA](#transfer-out)
 
 ### Set up a cash ISA
@@ -38,14 +37,14 @@ The sections below explain how to:
 When creating a new cash ISA, you need to first create the account, then set up the nominated account.
 
 <Callout colour="blue">
-If the customer does not already exist, you need to first create a retail customer using the <a href="../embedded-banking/fscs-protected-deposits#create-a-retail-customer">POST /v1/customers/retail</a> endpoint.
+If the customer does not already exist, you need to first create a retail customer using the <a href="../embedded-banking/retail-customers#create-a-retail-customer">POST /v1/customers/retail</a> endpoint.
 </Callout>
 
 To set up a cash ISA:
 
-1. Use the [POST /v1/isas](#create-an-cash-isa) endpoint to create the account
+1. Use the [POST /v1/isas](#create-a-cash-isa) endpoint to create the account
 > You cannot deposit funds into the cash ISA before the nominated account has been defined. 
-2. After receiving the Account Created webhook, use the [PUT /v1/accounts/{accountId}/nominated-account](#set-up-a-nominated-account) endpoint to define the nominated account for the cash ISA
+2. After receiving the Account Created webhook, use the [PUT /v1/accounts/{accountId}/nominated-account](#set-a-nominated-account) endpoint to define the nominated account for the cash ISA
 > You can now deposit funds into the cash ISA.
 
 The process is shown in this message flow diagram:
@@ -90,7 +89,7 @@ To close a cash ISA:
 1. Withdraw all funds from the cash ISA.
 2. Use the [POST /v1/accounts/{accountId}/closure](#close-a-cash-isa) endpoint to request the account closure. 
 > This process is asynchronous. The cash ISA is now frozen. Once the request is accepted, the account closure is pending until, if the account has accrued interest, the last interest payment is calculated and paid. This interest payment will be made to the nominated account. Once the payment has completed, the account will be closed.
-3. OPTIONAL Use the [GET /v1/accounts/{accountId}/closure](#check-cash-isa-closure-status) endpoint to check whether the account has been closed.
+3. OPTIONAL Use the [GET /v1/accounts/{accountId}/closure](#get-cash-isa-closure-status) endpoint to check whether the account has been closed.
 4. You will receive either the Account Closure Completed or Account Closure Failed webhook once the account closure process has completed.
 
 If the account closure fails, re-request the closure.
@@ -351,15 +350,15 @@ You can also transfer a cash ISA to another provider. Once the transfer out is s
 
 During the transfer out process, you move funds to a transfer out hub account created during onboarding. The cash ISA is then frozen. If the transfer out is successful, you can then move the funds from the transfer out hub to the new provider's account. There is a mandatory 15 day waiting period before you can close the account. If you requested a transfer out on the 1st of the month, the waiting period ends at 00:00 on the 16th. After that, you can close the account.
 
-If the transfer out fails, the new provider will provide you a reason the transfer failed and they will return funds to the transfer out hub. Use the [POST /v1/isas/{accountId}/transfer-outs/rejection](#transfer-out-rejected) endpoint to let ClearBank know the transfer out was unsuccessful and to unfreeze the account and return the account to the state it was before you requested the transfer out. Once the account is unfrozen, transfer the funds back into the cash ISA. The cash ISA will now continue to exist.
+If the transfer out fails, the new provider will provide you a reason the transfer failed and they will return funds to the transfer out hub. Use the [POST /v1/isas/{accountId}/transfer-outs/rejection](#reject-a-transfer-out) endpoint to let ClearBank know the transfer out was unsuccessful and to unfreeze the account and return the account to the state it was before you requested the transfer out. Once the account is unfrozen, transfer the funds back into the cash ISA. The cash ISA will now continue to exist.
 
 To transfer out a cash ISA:
-1. Use the [POST /v1/isas/{accountId}/transfer-outs](#transfer-out-a-cash-ISA).
+1. Use the [POST /v1/isas/{accountId}/transfer-outs](#transfer-out-a-cash-isa).
 > The cash ISA is now frozen. Only accrued interest, if any, can be credited to the account, and only the full balance can be withdrawn from the account.
 2. Once the account has been credited the final interest payment, withdraw the full balance of the account to the transfer out hub account created during onboarding. From there, you can send the funds to the new provider.
 3. Wait at least the remainder of the 15 working day waiting period to ensure the transfer out has been successful.
 4. Once the transfer has successfully completed, use the [POST /v1/accounts/{accountId}/closure](#close-a-cash-isa) endpoint to request the account closure.
-5. OPTIONAL Use the [GET /v1/accounts/{accountId}/closure](#check-cash-isa-closure-status) endpoint to check whether the account has been closed.
+5. OPTIONAL Use the [GET /v1/accounts/{accountId}/closure](#get-cash-isa-closure-status) endpoint to check whether the account has been closed.
 6. You will receive either the Account Closure Completed or Account Closure Failed webhook once the account closure process has completed.
 
 The process is shown in this message flow diagram:

--- a/content/uk/docs/gbp-accounts/account-reporting.mdx
+++ b/content/uk/docs/gbp-accounts/account-reporting.mdx
@@ -8,9 +8,9 @@ import EndpointBlock from "src/components/endpoint-block";
 import WebhookPlaceholder from 'src/components/webhook-placeholder'
 import Callout from "src/components/callout";
 
-## Statements
+## Camt.053 statements
 
-You can request a statement containing all payment activity across your ClearBank accounts for a completed business day, also referred to as a 'Bank to Customer Statement'. The statement is delivered in an ISO 20022 compliant XML file known as camt.053 (Cash Management message).
+You can request a statement containing all payment activity across your ClearBank accounts (sterling and multi-currency) for a completed business day, also referred to as a 'Bank to Customer Statement'. The statement is delivered in an ISO 20022 compliant XML file known as camt.053 (Cash Management message).
 
 The statement is populated with transaction activity across all of your accounts within a given time range. Note that a transaction must be in a **Settled** state to be included. The **startDateTime** and **endDateTime** in your statement request must:
 - be less than or equal to 25 hours apart

--- a/content/uk/docs/lookup/webhook-lookup-table.mdx
+++ b/content/uk/docs/lookup/webhook-lookup-table.mdx
@@ -35,7 +35,7 @@ The rows are ordered alphabetically based on the webhook type.
 | [BacsMandateReturnFailed](../gbp-payments/bacs-direct-debit-instructions#bacs-mandate-return-failed-webhook) | 1 | Notification that a Bacs Direct Debit Instruction Return has failed |
 | [BacsUnappliedCreditReceivedV3](../gbp-payments/bacs#bacs-unapplied-credit-received-webhook) | 3 | Notification that a Bacs Unapplied Credit has been received |
 | [BacsUnpaidDirectDebitReceivedV3](../gbp-payments/bacs#bacs-unpaid-direct-debit-received-webhook) | 3 | Notification that a Bacs Unpaid Direct Debit has been received |
-| [ChequeFailedScrutiny](../gbp-payments/cheques#cheque-scrutiny-failed-webhook) | 1 | (Simulation environment only) Notification that a cheque has failed scrutiny and will not be paid |
+| [ChequeFailedScrutiny](../gbp-payments/cheques#cheque-failed-scrutiny-webhook) | 1 | Notification that a cheque has failed scrutiny and will not be paid |
 | [ChequeNotPaid](../gbp-payments/cheques#cheque-not-paid-webhook) | 1 | Notification that a cheque has been received and will not be paid |
 | [ChequePaid](../gbp-payments/cheques#cheque-paid-webhook) | 1 | Notification that a cheque has been received and will be paid |
 | [ChequeReconciled](../gbp-payments/cheques#cheque-reconciled-webhook) | 1 | Notification that a cheque has been received, manually processed, and will be paid |

--- a/content/uk/docs/multi-currency/account-reporting.mdx
+++ b/content/uk/docs/multi-currency/account-reporting.mdx
@@ -6,6 +6,7 @@ showPageMenu: true
 
 import EndpointBlock from "src/components/endpoint-block";
 import WebhookPlaceholder from 'src/components/webhook-placeholder'
+import Callout from "src/components/callout";
 
 ## Multi-currency transactions
 
@@ -15,6 +16,10 @@ Multi-currency transaction endpoints allow you to retrieve:
 - A single transaction
 
 You can also access [Multi-currency statements](#multi-currency-statements).
+
+<Callout colour="blue">
+For camt.053 statements containing all payment activity across your ClearBank accounts (sterling and multi-currency), see <a href="../gbp-accounts/account-reporting">Account reporting</a>.
+</Callout>
 
 <EndpointBlock
   type="get"
@@ -54,6 +59,10 @@ You can also access [Multi-currency statements](#multi-currency-statements).
 Your multi-currency bank statement is an official summary of financial transactions that have occurred for all multi-currency accounts within a calendar month.
 
 Statements can be generated either for all accounts associated with your institution, or for a specified real account associated with your institution. The statement will be provided via a webhook (see [Use webhooks](../api/getting-started/#use-webhooks)).
+
+<Callout colour="blue">
+For camt.053 statements containing all payment activity across your ClearBank accounts (sterling and multi-currency), see <a href="../gbp-accounts/account-reporting">Account reporting</a>.
+</Callout>
 
 <EndpointBlock
   type="post"

--- a/webhooks/cheque-scrutiny-webhook-v1.mdx
+++ b/webhooks/cheque-scrutiny-webhook-v1.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Cheque Scrutiny Failed webhook"
+title: "Cheque Failed Scrutiny webhook"
 version: 1
 webhook: true
 ---
 
-A new webhook is being added to confirm a cheque has failed scrutiny and provide a reason for that failure using a four character reason code as the `ScrutinyFailureReasonCode`. Note that this webhook is only currently live in our simulation environment and **might change**. This page will be updated again once the webhook is finalised and moved into production.
+This webhook is used to confirm a cheque has failed scrutiny and provide a reason for that failure using a four character reason code as the `ScrutinyFailureReasonCode`.
 
 The table below covers common scenarios that can trigger this event. We cannot provide a complete list as these may change. The scenarios provided are designed to be human-readable, and you should be prepared to accept other values in these fields.
 
@@ -50,7 +50,7 @@ The table below covers common scenarios that can trigger this event. We cannot p
 | `CollectionChannel`          |**Required**<br/>Advises the Collection Channel of the original deposit made. Possible values: M (Mobile channel - ClearBank's service) or P (Postal channel).<br/>Type: `string`<br/>Max. Length: `1`<br/>Min. Length: `1`|
 | `TimestampCreated`           |**Required**<br/>The date and time (in UTC) when the cheque failed the scrutiny process within our system.<br/>Type: `string`<br/>Format: `date-time`|
 
-#### Example Cheque Scrutiny Failed webhook request body
+#### Example Cheque Failed Scrutiny webhook request body
 
 ```json
 {


### PR DESCRIPTION
- Amend title and description of Cheque Failed Scrutiny webhook
- Add clarification that camt.053 statements include multi-currency accounts