### PR TITLE
Add SEPA CT return '409 conflict' response

### DIFF
--- a/data/endpoints/sepa-ct-v1.json
+++ b/data/endpoints/sepa-ct-v1.json
@@ -258,6 +258,9 @@
                     },
                     "400": {
                         "description": "Bad Request"
+                    },
+                    "409": {
+                        "description": "Conflict"
                     }
                 }
             }


### PR DESCRIPTION
* Added 409 response to payment-returns endpoint
* Response body is not yet provided by endpoint, this will be added in January