### PR TITLE
GBP Cross-Border version 3 doc update

### DIFF
--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -14,14 +14,14 @@ import Callout from "src/components/callout";
 - <strong>POST /payments/cross-border-sterling/v1/payments</strong><br />
 - <strong>POST /payments/cross-border-sterling/v2/payments</strong><br /></p>
 
- <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to the new version of these endpoints once details are available. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="https://clearbank.github.io/uk/docs/api/versioning">versioning policy</a> and <a href="https://clearbank.github.io/uk/docs/api/support-life-cycle">support lifecycle information</a>.</p></Callout>
+ <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 3 now. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="https://clearbank.github.io/uk/docs/api/versioning">versioning policy</a> and <a href="https://clearbank.github.io/uk/docs/api/support-life-cycle">support lifecycle information</a>.</p></Callout>
 
 Cross-border payments are financial transactions where the payer and the recipient are based in separate countries. Our GBP Cross-Border payment product enables you to send sterling payments to any sterling account, in any permissible overseas jurisdiction. 
 Payments are guaranteed to settle on the same-day, as long as the instruction is received before 5pm UK time on that working day.
 
 There is no limit to the amount that can be sent using this service.
 
-You can send GBP cross-border payments using the [POST /payments/cross-border-sterling/v2/payments](#send-a-gpb-cross-border-payment) endpoint. 
+You can send GBP cross-border payments using the [POST /payments/cross-border-sterling/v3/payments](#send-a-gpb-cross-border-payment) endpoint. 
 
 Settlement details are provided to you via the [Transaction Settled](#transaction-settled-webhook) webhook. 
 
@@ -70,6 +70,8 @@ The character set defined by the pattern for the `name` and `reference` fields i
 ### Version 3 mandatory fields
 In line with the Bank of England's ISO 20022 data enhancement requirements, you will be required to provide additional details on the debtor and creditor such as the Legal Entity Identifier (LEI), Purpose Code and Category Purpose Code.
 
+You can find further details about these fields on our Knowledge Centre, or access a list of all the recommended Purpose and Category Purpose Codes and their definitions on the Bank of England website: [UK recommended Purpose Code PDF](https://www.bankofengland.co.uk/-/media/boe/files/payments/rtgs-renewal-programme/iso-20022/uk-recommended-purpose-code-list.pdf)  
+
 #### Legal Entity Identifer (LEI)
 The LEI is a 20-character, alpha-numeric code based on the ISO 17442 standard and contains information about an entity’s ownership structure. Providing the LEI is mandatory for pacs.008 where the party being described (debtor or creditor) is a financial institution. Otherwise, it is an optional field but strongly recommended to include when the party is an organisation.
 
@@ -93,7 +95,7 @@ For your convenience, Purpose Codes and Category Purpose Codes with the same val
 | 3 | Corporate | These codes can be used if the payment relates to topics that impact corporations. | ADCS, AGRT, BEXP, **BONU**, COMC, COMM, COMP, COMT, CPYR, DEPT, DIVD, ECPR, EPAY, GDSV, GIFT, GSCB, HREC, INSM, PEFC, REBT, REFU, RELG, ROYA, TRAD, **SUPP**, **PENS** | **BONU**, DIVI, DVPM, **PENS**, RRCT, **SUPP** | 
 | 4 | Tax & government specific | These codes can be used if the payment relates to tax or for government related activities. | ESTX, FAND, **GOVT**, HSTX, PENO, RDTX, TAXR, **TAXS**, **VATX**, **WHLD**, PTXP | **GOVT**, **TAXS**, **VATX**, **WHLD** | 
 | 5 | Insurance | These codes can be used if the payment relates to insurance. | HLTI, INPC, INPR, INSC, INSU, INTX, LBRI, LIFI, PPTI | N/A | 
-| 6 | Property | These codes must be used if the payment is related to property. The Bank of England are most interested in identifying when payments related to property have taken place. | HLRP, HLST, PCOM, PDEP, PLDS, PLRF | N/A | 
+| 6 | Property | These codes must be used if the payment is related to property. **It is a priority to identify these payments correctly**. | HLRP, HLST, PCOM, PDEP, PLDS, PLRF | N/A | 
 | 7 | Financial products | These codes can be used if the payment relates to a financial product. | BKFE, BNET, BOCE, **CBLK**, CMDT, COLL, **CORT**, DERI, EXTD, FNET, FORW, FREX, FUTR, FXNT, **HEDG**, INVS, OTCD, REPO, SBSC, **SECU**, SLEB, SWFP, SWPP, SWRS, SWUF, LREB, LREV | **CBLK**, **CORT**, **HEDG**, TRAD, **SECU** | 
 | 8 | Bills and fees | These codes can be used if the payment being made is related to a bill or fee being applied. | CBTV, CDBL, LICF, SERV, TCSC, UBIL, WTER, PHON, ELEC, GASB, CPKC, FEES, BLDM, DBTC, RENT | CCRD, DCRD, FCOL | 
 | 9 | Miscellaneous | Other or miscellaneous reason(s). | N/A | OTHR | 


### PR DESCRIPTION
* Add more detail on Purpose Codes - including link to Bank of England PDF.
* Correct references to v2 to point to v3

Update to documentation only, no change to API functionality.