### PR TITLE
All pages metaTitle documentation update

### DIFF
--- a/content/eu/docs/accounts.mdx
+++ b/content/eu/docs/accounts.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Accounts"
-order: 2
 metaTitle: "European accounts"
+order: 2
 metaDescription: ""
 showPageMenu: true
 ---

--- a/content/eu/docs/accounts/account-types.mdx
+++ b/content/eu/docs/accounts/account-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Euro account types"
+metaTitle: "Euro account types"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/accounts/manage-real-accounts.mdx
+++ b/content/eu/docs/accounts/manage-real-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manage real accounts"
+metaTitle: "Manage real accounts"
 order: 2
 showPageMenu: true
 ---

--- a/content/eu/docs/accounts/manage-virtual-accounts.mdx
+++ b/content/eu/docs/accounts/manage-virtual-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manage virtual accounts"
+metaTitle: "Manage virtual accounts"
 order: 3
 showPageMenu: true
 ---

--- a/content/eu/docs/api.mdx
+++ b/content/eu/docs/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: "API"
-order: 1
 metaTitle: "API"
+order: 1
 metaDescription: ""
 showPageMenu: true
 ---

--- a/content/eu/docs/api/getting-started.mdx
+++ b/content/eu/docs/api/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting started"
+metaTitle: "Getting started"
 order: 2
 showPageMenu: true
 bannerSrc: "\/assets\/images\/Developer Portal Banner EU Cropped.jpg"

--- a/content/eu/docs/api/overview.mdx
+++ b/content/eu/docs/api/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-metaTitle: "EU Overview"
+metaTitle: "EU API Overview"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/api/overview.mdx
+++ b/content/eu/docs/api/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+metaTitle: "EU Overview"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/api/support-life-cycle.mdx
+++ b/content/eu/docs/api/support-life-cycle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Support life cycle"
+metaTitle: "Support life cycle"
 order: 4
 showPageMenu: true
 ---

--- a/content/eu/docs/api/versioning.mdx
+++ b/content/eu/docs/api/versioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versioning"
+metaTitle: "Versioning"
 order: 3
 showPageMenu: true
 ---

--- a/content/eu/docs/eur-payments/sepa-ct.mdx
+++ b/content/eu/docs/eur-payments/sepa-ct.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SEPA CT"
+metaTitle: "SEPA CT"
 order: 2
 showPageMenu: true
 ---

--- a/content/eu/docs/eur-payments/sepa-instant-credit-transfer.mdx
+++ b/content/eu/docs/eur-payments/sepa-instant-credit-transfer.mdx
@@ -1,5 +1,6 @@
 ---
 title: "SEPA Instant CT"
+metaTitle: "SEPA Instant CT"
 order: 3
 showPageMenu: true
 ---

--- a/content/eu/docs/eur-payments/t2.mdx
+++ b/content/eu/docs/eur-payments/t2.mdx
@@ -1,5 +1,6 @@
 ---
 title: "T2"
+metaTitle: "T2"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/eu/docs/lookup/endpoint-lookup-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Endpoint lookup table"
-metaTitle: "Endpoint lookup table"
+metaTitle: "EU endpoint lookup table"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/eu/docs/lookup/endpoint-lookup-table.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Endpoint lookup table"
+metaTitle: "Endpoint lookup table"
 order: 1
 showPageMenu: true
 ---

--- a/content/eu/docs/lookup/webhook-lookup-table.mdx
+++ b/content/eu/docs/lookup/webhook-lookup-table.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhook lookup table"
+metaTitle: "Webhook lookup table"
 order: 2
 showPageMenu: true
 ---

--- a/content/eu/docs/lookup/webhook-lookup-table.mdx
+++ b/content/eu/docs/lookup/webhook-lookup-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webhook lookup table"
-metaTitle: "Webhook lookup table"
+metaTitle: "EU webhook lookup table"
 order: 2
 showPageMenu: true
 ---

--- a/content/eu/docs/report/statements.mdx
+++ b/content/eu/docs/report/statements.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Statements"
+metaTitle: "Statements"
 order: 2
 showPageMenu: true
 ---
@@ -14,7 +15,8 @@ Your bank statement is an official summary of financial transactions that have o
 
 Statements can be generated either for all your accounts, or for a specified real account. The statement will be provided via a webhook (refer to [Use webhooks](../api/getting-started/#use-webhooks)).
 
-<Callout colour="blue">The only currency we support in Europe is euro. Set currency to EUR for all statement requests.
+<Callout colour="blue">
+The only currency we support in Europe is euro. Set currency to EUR for all statement requests.
 </Callout> 
 
 <EndpointBlock

--- a/content/eu/docs/report/transactions.mdx
+++ b/content/eu/docs/report/transactions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Transactions"
+metaTitle: "Transactions"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/api/getting-started.mdx
+++ b/content/uk/docs/api/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting started"
+metaTitle: "Getting started"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/api/overview.mdx
+++ b/content/uk/docs/api/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Overview"
+metaTitle: "API Overview"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/api/overview.mdx
+++ b/content/uk/docs/api/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-metaTitle: "API Overview"
+metaTitle: "UK API Overview"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/api/support-life-cycle.mdx
+++ b/content/uk/docs/api/support-life-cycle.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Support life cycle"
+metaTitle: "Support life cycle"
 order: 4
 showPageMenu: true
 ---

--- a/content/uk/docs/api/versioning.mdx
+++ b/content/uk/docs/api/versioning.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Versioning"
+metaTitle: "API Versioning"
 order: 3
 showPageMenu: true
 ---

--- a/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
+++ b/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Flexible cash ISAs"
+metaTitle: "Flexible cash ISAs"
 order: 3
 showPageMenu: true
 ---

--- a/content/uk/docs/embedded-banking/retail-customers.mdx
+++ b/content/uk/docs/embedded-banking/retail-customers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Retail customers"
+metaTitle: "Retail customers"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/embedded-banking/savings-accounts.mdx
+++ b/content/uk/docs/embedded-banking/savings-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Savings accounts"
+metaTitle: "Savings accounts"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-accounts/account-reporting.mdx
+++ b/content/uk/docs/gbp-accounts/account-reporting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account reporting"
+metaTitle: "Account reporting"
 order: 5
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-accounts/account-types.mdx
+++ b/content/uk/docs/gbp-accounts/account-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account types"
+metaTitle: "Account types"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-accounts/bacs-payment-data.mdx
+++ b/content/uk/docs/gbp-accounts/bacs-payment-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bacs payment data"
+metaTitle: "Bacs payment data"
 order: 4
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-accounts/manage-accounts.mdx
+++ b/content/uk/docs/gbp-accounts/manage-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manage sterling accounts"
+metaTitle: "Manage sterling accounts"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-accounts/payment-data.mdx
+++ b/content/uk/docs/gbp-accounts/payment-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Payment data"
+metaTitle: "Payment data"
 order: 3
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/bacs-direct-debit-instructions.mdx
+++ b/content/uk/docs/gbp-payments/bacs-direct-debit-instructions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bacs Direct Debit Instructions"
+metaTitle: "Bacs Direct Debit Instructions"
 order: 4
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/bacs.mdx
+++ b/content/uk/docs/gbp-payments/bacs.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bacs"
+metaTitle: "Bacs"
 order: 3
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -1,5 +1,6 @@
 ---
 title: "CHAPS"
+metaTitle: "CHAPS"
 order: 5
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/cheques.mdx
+++ b/content/uk/docs/gbp-payments/cheques.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Cheques"
+metaTitle: "Cheques"
 order: 6
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/confirmation-of-payee.mdx
+++ b/content/uk/docs/gbp-payments/confirmation-of-payee.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Confirmation Of Payee (CoP)"
+metaTitle: "Confirmation Of Payee (CoP)"
 order: 8
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/faster-payments.mdx
+++ b/content/uk/docs/gbp-payments/faster-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Faster payments"
+metaTitle: "Faster payments"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -1,5 +1,6 @@
 ---
 title: "GBP Cross-Border"
+metaTitle: "GBP Cross-Border"
 order: 7
 showPageMenu: true
 ---

--- a/content/uk/docs/gbp-payments/internal-transfers.mdx
+++ b/content/uk/docs/gbp-payments/internal-transfers.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Internal transfers"
+metaTitle: "Internal transfers"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/index.mdx
+++ b/content/uk/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Home"
 order: -1
-metaTitle: "This is the title tag of this page"
+metaTitle: "Home"
 metaDescription: ""
 ---

--- a/content/uk/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/uk/docs/lookup/endpoint-lookup-table.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Endpoint lookup table"
+metaTitle: "Endpoint lookup table"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/uk/docs/lookup/endpoint-lookup-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Endpoint lookup table"
-metaTitle: "Endpoint lookup table"
+metaTitle: "UK endpoint lookup table"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/lookup/webhook-lookup-table.mdx
+++ b/content/uk/docs/lookup/webhook-lookup-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Webhook lookup table"
-metaTitle: "Webhook lookup table"
+metaTitle: "UK webhook lookup table"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/lookup/webhook-lookup-table.mdx
+++ b/content/uk/docs/lookup/webhook-lookup-table.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Webhook lookup table"
+metaTitle: "Webhook lookup table"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/account-reporting.mdx
+++ b/content/uk/docs/multi-currency/account-reporting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Account reporting"
+metaTitle: "Account reporting"
 order: 3
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/fx-trade-rfq.mdx
+++ b/content/uk/docs/multi-currency/fx-trade-rfq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FX trade (RFQ)"
+metaTitle: "FX trade (RFQ)"
 order: 6
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/fx-trade.mdx
+++ b/content/uk/docs/multi-currency/fx-trade.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FX trade"
+metaTitle: "FX trade"
 order: 5
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/manage-multi-currency-accounts.mdx
+++ b/content/uk/docs/multi-currency/manage-multi-currency-accounts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Manage multi-currency accounts"
+metaTitle: "Manage multi-currency accounts"
 order: 2
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/multi-currency-account-types.mdx
+++ b/content/uk/docs/multi-currency/multi-currency-account-types.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Multi-currency account types"
+metaTitle: "Multi-currency account types"
 order: 1
 showPageMenu: true
 ---

--- a/content/uk/docs/multi-currency/multi-currency-payments.mdx
+++ b/content/uk/docs/multi-currency/multi-currency-payments.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Multi-currency payments"
+metaTitle: "Multi-currency payments"
 order: 4
 showPageMenu: true
 ---

--- a/src/components/footer/__snapshots__/footer.spec.tsx.snap
+++ b/src/components/footer/__snapshots__/footer.spec.tsx.snap
@@ -68,7 +68,7 @@ exports[`Component matches snapshot 1`] = `
     >
       <h5>
         Copyright © ClearBank Limited 
-        2024
+        2025
         . All rights reserved.
       </h5>
       ClearBank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial Conduct Authority and the Prudential Regulation Authority (FRN: 754568). Registered in England and Wales under Company Number 09736376. Registered Address: ClearBank Limited, Borough Yards, 13 Dirty Lane, London, SE1 9PA.

--- a/src/components/layout/__snapshots__/layout.spec.tsx.snap
+++ b/src/components/layout/__snapshots__/layout.spec.tsx.snap
@@ -415,7 +415,7 @@ exports[`Component matches snapshot 1`] = `
             class="c16 long-primer"
           />
           <h5>
-            Copyright © ClearBank Limited 2024. All rights reserved.
+            Copyright © ClearBank Limited 2025. All rights reserved.
           </h5>
           ClearBank Limited is authorised by the Prudential Regulation Authority and regulated by the Financial Conduct Authority and the Prudential Regulation Authority (FRN: 754568). Registered in England and Wales under Company Number 09736376. Registered Address: ClearBank Limited, Borough Yards, 13 Dirty Lane, London, SE1 9PA.
           <br />

--- a/src/containers/doc/doc.tsx
+++ b/src/containers/doc/doc.tsx
@@ -59,7 +59,7 @@ export const Head: React.FC<any> = ({ data }) => {
 
   return (
     <>
-      {metaTitle ? <title>{metaTitle} | ClearBank® Developer Portal</title> : null}
+      {metaTitle ? <title>{metaTitle} | ClearBank Developer Portal</title> : null}
       {metaTitle ? <meta name='title' content={metaTitle} /> : null}
       {metaDescription ? (
         <meta name='description' content={metaDescription} />


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

All docs pages have had a metaTitle tag added. Browser tabs will now render the page's title instead of its URL