### PR TITLE
GBP Accounts relax OwnerName pattern

### DIFF
--- a/content/uk/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/uk/docs/lookup/endpoint-lookup-table.mdx
@@ -15,7 +15,7 @@ The rows are ordered alphabetically based on the path, ignoring the version numb
 | ----------- |  ----------- |
 | [GET /v3/Accounts](../gbp-accounts/manage-accounts#get-all-accounts-real) | Get all accounts associated with your institution |
 | [POST /v3/Accounts](../gbp-accounts/manage-accounts#create-an-account-real) | Create an account with the specified name |
-| [POST /v4/Accounts](../embedded-banking/fscs-protected-deposits#create-an-account) | Create a new FSCS-protected current account |
+| [POST /v4/Accounts](../embedded-banking/retail-customers#create-an-account) | Create a new FSCS-protected current account |
 | [GET /v3/Accounts/{accountId}](../gbp-accounts/manage-accounts#get-information-for-an-account-real) | Get a detailed view of an account |
 | [PATCH /v1/Accounts/{accountId}](../gbp-accounts/manage-accounts#amend-an-account-real) | Amend the properties of an existing account |
 | [GET /v1/accounts/{accountId}/closure](../embedded-banking/flexible-cash-isa#check-cash-isa-closure-status) | Get savings account or flexible cash ISA closure status |
@@ -50,9 +50,9 @@ The rows are ordered alphabetically based on the path, ignoring the version numb
 | [GET /v1/Accounts/Virtual](../gbp-accounts/manage-accounts#get-accounts-virtual) | Get a list of all the virtual accounts belonging to an institution |
 | [PUT /v1/Cop/opt/accounts/{accountId}](../gbp-payments/confirmation-of-payee#opt-out-from-the-cop-service-real-account) | Update an account to either opt out or opt back into our Confirmation of Payee (CoP) service |
 | [PUT /v1/Cop/opt/accounts/{accountId}/virtual/{virtualAccountId}](../gbp-payments/confirmation-of-payee#opt-out-from-the-cop-service-virtual-account) | Update a virtual account to either opt out or opt back into  our Confirmation of Payee (CoP) service |
-| [POST /v1/customers/retail](../embedded-banking/fscs-protected-deposits#create-a-retail-customer) | Create a new retail customer |
-| [PATCH /v1/customers/retail/{customerId}](../embedded-banking/fscs-protected-deposits#update-an-existing-retail-customers-personal-information) | Update the details of an existing retail customer |
-| [PUT /v1/customers/retail/{customerId}/currentaddress](../embedded-banking/fscs-protected-deposits#update-an-existing-retail-customers-address) | Update the address of an existing retail customer |
+| [POST /v1/customers/retail](../embedded-banking/retail-customers#create-a-retail-customer) | Create a new retail customer |
+| [PATCH /v1/customers/retail/{customerId}](../embedded-banking/retail-customers#update-an-existing-retail-customers-personal-information) | Update the details of an existing retail customer |
+| [PUT /v1/customers/retail/{customerId}/currentaddress](../embedded-banking/retail-customers#update-an-existing-retail-customers-address) | Update the address of an existing retail customer |
 | [POST /fx/v1/ExecuteQuote](../multi-currency/fx-trade-rfq#execute-a-quote) | Execute a FX trade using the rate received in a quote (must be executed within the held rate period of 45 seconds) |
 | [POST /fx/v1/order](../multi-currency/fx-trade#create-a-foreign-exchange-fx-buy-and-sell-order) | Create a Foreign Exchange (FX) trade with the buy or sell amount specified |
 | [POST /fx/v1/quote](../multi-currency/fx-trade-rfq#request-a-quote) | Request a quote up-front for a FX trade |

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7487,7 +7487,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 0,
-            "pattern": "^[a-zA-Z0-9@#;:\\-?().,+=!\"%*<>{}&/\\s]*$",
+            "pattern": "^[a-zA-Z0-9@#;:\\-?().,'+=!\"%*{}&/\\s]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the account.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7856,7 +7856,7 @@
           "ownerName": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[^<!|$*;^%_>`#@=\"~\\[\\]{}\\\\]*$",
+            "pattern": "^[a-zA-Z0-9@#;:\\-?().,'+=!\"%*{}&/\\s]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the account.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7968,7 +7968,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 0,
-            "pattern": "^[^<!|$*;^%_>`#@=\"~\\[\\]{}\\\\]*$",
+            "pattern": "^[a-zA-Z0-9@#;:\\-?().,'+=!\"%*{}&/\\s]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the virtual account.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7541,6 +7541,7 @@
           "ownerName": {
             "maxLength": 140,
             "minLength": 0,
+            "pattern": "^[0-9a-zA-Z\/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\"\";<>@\\[\\\\]]+$",
             "type": "string",
             "description": "The name used to identify the legal owner of the nominated account.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3581,7 +3581,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 1,
-            "pattern": "^[^<!|$*;^%_>`#@=\"~\\[\\]{}\\\\]*$",
+            "pattern": "^[a-zA-Z0-9@#;:\\-?().,'+=!\"%*{}&/\\s]*$",
             "type": "string",
             "description": "Virtual account owner name (account holder label).",
             "example": "John Smith"

--- a/data/endpoints/sterling-v4.json
+++ b/data/endpoints/sterling-v4.json
@@ -320,7 +320,7 @@
           "name": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[a-zA-Z0-9@#;:\\-?().,+=!\"%*<>{}&/\\s]*$",
+            "pattern": "^[a-zA-Z0-9@#;:\\-?().,'+=!\"%*{}&/\\s]*$",
             "type": "string",
             "description": "Name for the owner of the current account.",
             "example": "John Smith"


### PR DESCRIPTION
This is a non-breaking change.
The following endpoints have the OwnerName field's regex pattern relaxed:
* POST /v4/Accounts
* PATCH /v1/accounts/{accountId}
* POST /v1/savings
* POST /v2/Accounts/{accountId}/Virtual
* PATCH /v1/accounts/{accountId}/virtual/{virtualAccountId}
* PUT /v1/accounts/{accountId}/nominated-account