### PR TITLE
Cross-border GBP set mandatory field

### DIFF
--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -622,7 +622,8 @@
     },
     "CustomerPartyDetailsDtoV5": {
         "required": [
-            "name"
+            "name",
+            "postalAddress"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
Creditor and Debtor address fields are now mandatory for the Cross Border v3 endpoint