### PR TITLE
ISA Rejection endpoint - correct payment type options

### DIFF
--- a/content/eu/docs/lookup/endpoint-lookup-table.mdx
+++ b/content/eu/docs/lookup/endpoint-lookup-table.mdx
@@ -29,7 +29,7 @@ The rows are ordered alphabetically based on the path, ignoring the version numb
 | [GET /mccy/v1/VirtualAccounts/{virtualAccountId}](../accounts/manage-virtual-accounts#get-information-for-an-account-virtual) | Get details related to a virtual account |
 | [PATCH /mccy/v1/VirtualAccounts/{virtualAccountId}](../accounts/manage-virtual-accounts#amend-the-properties-of-an-account-virtual) | Amend the properties of an existing virtual account |
 | [PATCH /mccy/v1/VirtualAccounts/{virtualAccountId}/status](../accounts/manage-virtual-accounts#update-the-status-of-an-account-virtual) | Update the status of an existing virtual account |
-| [GET /mccy/v1/VirtualAccounts/{virtualAccountId}/transactions](../accounts/account-reporting#get-transaction-list-for-a-virtual-account) | Get a list of transactions for a virtual account |
+| [GET /mccy/v1/VirtualAccounts/{virtualAccountId}/transactions](../report/transactions#get-transaction-list-for-a-virtual-account) | Get a list of transactions for a virtual account |
 | [POST /payments/sepa-ct/v1/customer-payments](../eur-payments/sepa-ct#send-a-sepa-ct-payment) |Send a SEPA CT customer payment|
 | [POST /payments/sepa-ct/v1/payment-returns](../eur-payments/sepa-ct#return-a-sepa-ct-payment) |Return a SEPA CT payment|
 | [POST /payments/sepa-ct/v1/recall](../eur-payments/sepa-ct#request-a-sepa-ct-payment-recall) |Recall a SEPA CT payment|

--- a/webhooks/isa-subscription-rejected-webhook-v1.mdx
+++ b/webhooks/isa-subscription-rejected-webhook-v1.mdx
@@ -32,7 +32,7 @@ This webhook confirms the ISA subscription (payment into the ISA) has failed and
 | `NetSubscription`                   | The net subscription for the ISA in the tax year. <br /> Type: `number` <br /> Format: `decimal`|
 | `RemainingSubscriptionAllowance`    | The remaining subscription allowance for the ISA in the tax year. <br /> Type: `number` <br /> Format: `decimal`|
 | `AnnualAllowanceUsed`    | The maximum value the net subscription reaches in the tax year. <br /> Type: `number`, `null` <br /> Format: `decimal`|
-| `PaymentMethodType`    | The payment method type of the subscription. <br /> Type: `null`, `string` <br />  Example: `Undefined`, `Transfer`, `FasterPayments`, `Bacs`, `CHAPS`, `Sepa`, `Visa`, `Mastercard` |
+| `PaymentMethodType`    | The payment method type of the subscription. <br /> Type: `null`, `string` <br />  Example: `Transfer`, `FasterPayments`, `Bacs`, `CHAPS` |
 | `DebtorAccountIdentifiers`    | The account identifiers of the debtor account of the subscription. <br /> Type: `null`, `string` <br /> Example: `IBAN`, `BBAN` |
 | `NominatedAccountIdentifiers`    | The account identifiers of the nominated account for the ISA. <br /> Type: `null`, `string` <br /> Example: `IBAN`, `BBAN` |
 | `DeclarationExpiryDate`    | The date the declaration expires (UTC). If null, the declaration is valid indefinitely. <br /> Type: `null`, `string` <br /> Format: `date-time`|


### PR DESCRIPTION
This is a documentation change only.
* Removed: Sepa, Visa, Mastercard, and Undefined from example PaymentMethodType
* Options are now: Transfer, FasterPayments, Bacs, and CHAPS
* _Unrelated: Fixed broken link on EU endpoint lookup_