### PR TITLE
T2 simulation endpoints InstructingAgent BIC

### DIFF
--- a/data/endpoints/t2-v1-sim.json
+++ b/data/endpoints/t2-v1-sim.json
@@ -622,8 +622,7 @@
                         "minLength": 11,
                         "type": "string",
                         "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}[A-Z0-9]{3,3}\\z",
-                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX.",
-                        "example": "CLRBNL2AXXX"
+                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX."
                     },
                     "lei": {
                         "type": "string",

--- a/data/endpoints/t2-v1-sim.json
+++ b/data/endpoints/t2-v1-sim.json
@@ -622,7 +622,7 @@
                         "minLength": 11,
                         "type": "string",
                         "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}[A-Z0-9]{3,3}\\z",
-                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX.",
+                        "description": "The instructing agent's BIC. For testing, must be CLRBNL2AXXX.",
                         "example": "CLRBNL2AXXX"
                     },
                     "lei": {

--- a/data/endpoints/t2-v1-sim.json
+++ b/data/endpoints/t2-v1-sim.json
@@ -622,7 +622,8 @@
                         "minLength": 11,
                         "type": "string",
                         "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}[A-Z0-9]{3,3}\\z",
-                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX."
+                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX.",
+                        "example": "CLRBNL2AXXX"
                     },
                     "lei": {
                         "type": "string",

--- a/data/endpoints/t2-v1-sim.json
+++ b/data/endpoints/t2-v1-sim.json
@@ -621,7 +621,8 @@
                         "maxLength": 11,
                         "minLength": 11,
                         "type": "string",
-                        "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}[A-Z0-9]{3,3}\\z"
+                        "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}[A-Z0-9]{3,3}\\z",
+                        "description": "The instructing agent's BIC. For testing, must be either CLRBNL2AXXX or FLORNL2AXXX."
                     },
                     "lei": {
                         "type": "string",


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

- Add specification for `InstructingAgent` > `BIC` field for all T2 inbound test payment endpoints