### PR TITLE
Fix: Transaction Settled Webhook - Amount Type

### DIFF
--- a/webhooks/transaction-settled-webhook-v6.mdx
+++ b/webhooks/transaction-settled-webhook-v6.mdx
@@ -24,7 +24,7 @@ This webhook confirms the transaction has settled. For Bacs payments, this is se
 | `Status`                      | Transaction status.<br />Type: `string`<br />`Settled` |
 | `Scheme`                      | *Optional* <br />The Scheme type.<br /> `Transfer`<br />`FasterPayments`<br />`Bacs`<br />`Chaps`|
 | `EndToEndTransactionId`       | For **outbound Faster Payments and CHAPS** transactions, this is the unique identifier you supplied in the endToEndIdentification field in your API request. <br /><br />For **inbound CHAPS** payments, this is the prefix "II-" followed by the Instruction Identification, which is unique. <br /><br />For **outbound cheque** transactions, this is the unique identifier you supplied in the MessageId value in your submit a cheque API request. <br /><br />For **internal transfers**, this will not be unique, as the value specified in the two webhooks describing the transactions applied to the debtor and creditor accounts will match. <br /><br />Type: `string`<br />Max. length:`35`|
-| `Amount`                      | Transaction amount. <br />Type: `int`|
+| `Amount`                      | Transaction amount. <br />Type: `decimal`|
 | `TimestampSettled`            | Date and time the transaction settled.<br /> Time Zone: `UTC`<br /> Type: `DateTime`|
 | `TimestampCreated`            | Date and time the transaction was created.<br /> Time Zone: `UTC`<br /> Type: `DateTime`|
 | `CurrencyCode`                | *Optional* <br />Code of transaction currency.<br /> `GBP`|


### PR DESCRIPTION
Update to documentation only, no change to API functionality

Amend Amount field of the Transaction Settled Webhook to type: decimal


























































