### PR TITLE
Add CHAPS V5 payment endpoints

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -16,7 +16,7 @@ import Callout from "src/components/callout";
 - <strong>POST payments/chaps/v4/institution-payments</strong><br />
 - <strong>POST payments/chaps/v4/return-payments</strong><br /></p>
 
- <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 5 of these endpoints once details are available. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="https://clearbank.github.io/uk/docs/api/versioning">versioning policy</a> and <a href="https://clearbank.github.io/uk/docs/api/support-life-cycle">support lifecycle information</a>.</p></Callout>
+ <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 5 of these endpoints. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="https://clearbank.github.io/uk/docs/api/versioning">versioning policy</a> and <a href="https://clearbank.github.io/uk/docs/api/support-life-cycle">support lifecycle information</a>.</p></Callout>
 
 ClearBank accounts support inbound and outbound CHAPS payments. As CHAPS is the UK’s high value payment scheme, there is no amount limit associated with inbound or outbound CHAPS payments.
 However, you can only send or return CHAPS payments between 08:00 – 17:00 Monday to Friday (excluding UK public holidays).

--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -63,6 +63,16 @@ The character set defined by the pattern for the `name` and `reference` fields i
     type="post"
     title="Send a CHAPS payment"
     endpoints={[
+        {
+        path: "/payments/chaps/v5/customer-payments",
+        version: "5.0.Chaps-payment",
+        webhooks: [
+        'transaction-settled-webhook-v6',
+        'payment-message-assessment-failed-webhook-v1',
+        'payment-message-validation-failed-webhook-v1',
+        'transaction-rejected-v2'
+        ]
+    },
     {
         path: "payments/chaps/v4/customer-payments",
         version: "4.0.Chaps-payment",
@@ -81,6 +91,16 @@ The character set defined by the pattern for the `name` and `reference` fields i
     type="post"
     title="Return a CHAPS payment"
     endpoints={[
+        {
+        path: "/payments/chaps/v5/return-payments",
+        version: "5.0-ChapsReturn",
+        webhooks: [
+        'transaction-settled-webhook-v6',
+        'payment-message-assessment-failed-webhook-v1',
+        'payment-message-validation-failed-webhook-v1',
+        'transaction-rejected-v2'
+        ]
+    },
     {
         path: "/payments/chaps/v4/return-payments",
         version: "4.0-ChapsReturn",
@@ -98,6 +118,17 @@ The character set defined by the pattern for the `name` and `reference` fields i
     type="post"
     title="Send a CHAPS bank-to-bank payment"
     endpoints={[
+        {
+        path: "/payments/chaps/v5/institution-payments",
+        version: "5.0_BankToBank",
+        webhooks: [
+        'transaction-settled-webhook-v6',
+        'payment-message-assessment-failed-webhook-v1',
+        'payment-message-validation-failed-webhook-v1',
+        'outbound-held-transaction-v1',
+        'transaction-rejected-v2'
+        ]
+    },
     {
         path: "/payments/chaps/v4/institution-payments",
         version: "4.0_BankToBank",

--- a/data/endpoints/chaps-bank-to-bank-v5.json
+++ b/data/endpoints/chaps-bank-to-bank-v5.json
@@ -178,6 +178,9 @@
                         "description": "Scheme type. If this field is set to 'Other', then the proprietary field is required."
                     },
                     "proprietary": {
+                        "enum": [
+                            "SortcodeAccountNumber"
+                        ],
                         "type": "string",
                         "description": "This field must be present when schemeName is set to 'Other' and should not be present otherwise."
                     },
@@ -480,7 +483,8 @@
                     "currency": {
                         "minLength": 1,
                         "example": "GBP",
-                        "type": "string"
+                        "type": "string",
+                        "description": "Set to 'GBP' as other currencies are not supported."
                     }
                 },
                 "additionalProperties": false,
@@ -541,7 +545,8 @@
             "PartyDetailsDtoV5": {
                 "required": [
                     "name",
-                    "lei"
+                    "lei",
+                    "postalAddress"
                 ],
                 "type": "object",
                 "properties": {
@@ -602,7 +607,7 @@
             "UnstructuredRemittanceInformationDtoV5": {
                 "type": "object",
                 "properties": {
-                    "creditorReferenceInformation": {
+                    "unstructured": {
                         "maxLength": 140,
                         "minLength": 1,
                         "type": "string",

--- a/data/endpoints/chaps-bank-to-bank-v5.json
+++ b/data/endpoints/chaps-bank-to-bank-v5.json
@@ -1,0 +1,618 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "ClearBank.Chaps.Rtgs.Api",
+        "version": "5.0_BankToBank"
+    },
+    "paths": {
+         "/payments/chaps/v5/institution-payments": {
+            "post": {
+                "tags": [
+                    "ExternalInstitutionPaymentsV5"
+                ],
+                "description": "Create an outbound bank-to-bank payment. This endpoint is used to send CHAPS Pacs.009 payments between financial institutions and is only available to authorised institutions.",
+                "operationId": "ExternalCreateInstitutionPayment-v5",
+                "parameters": [
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_Authorization"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_DigitalSignature"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_RequestIdentifier"
+                  }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateInstitutionPaymentDtoV5"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateInstitutionPaymentDtoV5"
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateInstitutionPaymentDtoV5"
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateInstitutionPaymentDtoV5"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                        }
+                                },
+                            "application/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                        }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    "components": {
+        "parameters": {
+            "ParametersOpenapi_Authorization": {
+              "name": "Authorization",
+              "in": "header",
+              "description": "Your API token retrieved from the ClearBank portal.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_AuthorizationType"
+              }
+            },
+            "ParametersOpenapi_DigitalSignature": {
+              "name": "DigitalSignature",
+              "in": "header",
+              "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_DigitalSignatureType"
+              }
+            },
+            "ParametersOpenapi_RequestIdentifier": {
+              "name": "X-Request-Id",
+              "in": "header",
+              "description": "A unique identifier for the request.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_RequestIdentifierType"
+              }
+            }
+          },
+        "schemas": {
+            "ApiHeadersSchema_AuthorizationType": {
+                "description": "Authorization header restricted to Bearer token only",
+                "type": "string",
+                "pattern": "^Bearer +.+"
+            },
+            "ApiHeadersSchema_DigitalSignatureType": {
+                "description": "The digital signature generated by the API consumer",
+                "type": "string"
+            },
+            "ApiHeadersSchema_RequestIdentifierType": {
+                "description": "The request identifier supplied by the API consumer",
+                "type": "string"
+            },
+            "AccountIdentificationDtoV5": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "AccountIdentificationIbanDtoV5": {
+                "required": [
+                    "iban"
+                ],
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/AccountIdentificationDtoV5"
+                }],
+                "properties": {
+                    "iban": {
+                        "minLength": 1,
+                        "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
+                        "type": "string",
+                        "description": "International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer. Further specifications of the format and content of the IBAN can be found in the standard ISO 13616 \"Banking and related financial services - International Bank Account Number (IBAN)\" version 1997-10-01, or later revisions."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "AccountIdentificationOtherDtoV5": {
+                "required": [
+                    "identification",
+                    "schemeName"
+                ],
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/AccountIdentificationDtoV5"
+                }],
+                "properties": {
+                    "schemeName": {
+                        "enum": [
+                            "BBan",
+                            "Other"
+                        ],
+                        "type": "string",
+                        "description": "Scheme type. If this field is set to 'Other', then the proprietary field is required."
+                    },
+                    "proprietary": {
+                        "type": "string",
+                        "description": "This field must be present when schemeName is set to 'Other' and should not be present otherwise."
+                    },
+                    "identification": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Unambiguous identification for the given scheme (specified in schemeName). Set to either the BBAN (XXXX01020301234567) or the sort code and account number (01020301234567)."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "AddressDetailsDtoV3": {
+                "type": "object",
+                "properties": {
+                    "buildingNumber": {
+                        "type": "string"
+                    },
+                    "buildingName": {
+                        "type": "string"
+                    },
+                    "streetName": {
+                        "type": "string"
+                    },
+                    "town": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "postCode": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "CreateInstitutionPaymentDtoV5": {
+                "required": [
+                    "creditor",
+                    "purpose",
+                    "categoryPurpose",
+                    "creditorAccount",
+                    "debtor",
+                    "endToEndIdentification",
+                    "instructedAmount",
+                    "instructionIdentification",
+                    "sourceAccount"
+                ],
+                "type": "object",
+                "properties": {
+                    "instructionIdentification": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction.\n\nUsage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                    },
+                    "endToEndIdentification": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
+                        "type": "string",
+                        "description": "Unique identification, as assigned by the initiating party, to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\n\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\n\nUsage: In case there are technical limitations to pass on multiple references, the end-to-end identification must be passed on throughout the entire end-to-end chain."
+                    },
+                    "instructedAmount": {
+                        "$ref": "#/components/schemas/InstructionAmountDtoV5"
+                    },
+                    "sourceAccount": {
+                        "type": "object",
+                        "oneOf": [{
+                                "$ref": "#/components/schemas/AccountIdentificationIbanDtoV5"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AccountIdentificationOtherDtoV5"
+                            }
+                        ],
+                        "description": "The ClearBank account that will be credited or debited based on the successful completion of the payment instruction."
+                    },
+                    "debtor": {
+                        "$ref": "#/components/schemas/PartyDetailsDtoV5"
+                    },
+                    "creditorAccount": {
+                        "type": "object",
+                        "oneOf": [{
+                                "$ref": "#/components/schemas/AccountIdentificationIbanDtoV5"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AccountIdentificationOtherDtoV5"
+                            }
+                        ],
+                        "description": "Party is owed an amount of money as the (ultimate) creditor."
+                    },
+                    "creditor": {
+                        "$ref": "#/components/schemas/PartyDetailsDtoV5"
+                    },
+                    "purpose": {
+                        "enum": [
+                            "BKFE",
+                            "BKIP",
+                            "BKPP",
+                            "CBLK",
+                            "ACCT",
+                            "CASH",
+                            "COLL",
+                            "CSDB",
+                            "DEPT",
+                            "INTC",
+                            "INTP",
+                            "LIMA",
+                            "NETT",
+                            "EXTD",
+                            "OTCD",
+                            "REPO",
+                            "SBSC",
+                            "SLEB",
+                            "AGRT",
+                            "AREN",
+                            "BEXP",
+                            "BOCE",
+                            "COMC",
+                            "CPYR",
+                            "GDSV",
+                            "GSCB",
+                            "LICF",
+                            "ROYA",
+                            "SERV",
+                            "SUBS",
+                            "SUPP",
+                            "TRAD",
+                            "CHAR",
+                            "COMT",
+                            "ECPR",
+                            "EPAY",
+                            "CLPR",
+                            "COMP",
+                            "DBTC",
+                            "HLRP",
+                            "HLST",
+                            "INPC",
+                            "INPR",
+                            "INSC",
+                            "INSU",
+                            "INTE",
+                            "LBRI",
+                            "LIFI",
+                            "LOAN",
+                            "LOAR",
+                            "PENO",
+                            "PPTI",
+                            "RELG",
+                            "TRFD",
+                            "FORW",
+                            "FXNT",
+                            "BLDM",
+                            "BNET",
+                            "CDBL",
+                            "CORT",
+                            "CPKC",
+                            "EDUC",
+                            "FAND",
+                            "FEES",
+                            "GIFT",
+                            "GOVT",
+                            "INSM",
+                            "IVPT",
+                            "REBT",
+                            "REFU",
+                            "RENT",
+                            "REOD",
+                            "TCSC",
+                            "CMDT",
+                            "DERI",
+                            "DIVD",
+                            "FREX",
+                            "HEDG",
+                            "INVS",
+                            "SAVG",
+                            "SECU",
+                            "TREA",
+                            "FNET",
+                            "FUTR",
+                            "DNTS",
+                            "HLTI",
+                            "LTCF",
+                            "MDCS",
+                            "VIEW",
+                            "SWFP",
+                            "SWPP",
+                            "SWRS",
+                            "SWUF",
+                            "ADCS",
+                            "ALMY",
+                            "BECH",
+                            "BENE",
+                            "BONU",
+                            "COMM",
+                            "HREC",
+                            "PEFC",
+                            "PENS",
+                            "SALA",
+                            "SSBE",
+                            "LREB",
+                            "LREV",
+                            "ESTX",
+                            "HSTX",
+                            "INTX",
+                            "PTXP",
+                            "RDTX",
+                            "TAXS",
+                            "VATX",
+                            "WHLD",
+                            "TAXR",
+                            "CBTV",
+                            "ELEC",
+                            "GASB",
+                            "PHON",
+                            "UBIL",
+                            "WTER",
+                            "GAMB",
+                            "LOTT",
+                            "PCOM",
+                            "PDEP",
+                            "PLDS",
+                            "PLRF"
+                        ],
+                        "type": "string",
+                        "example": "INTC",
+                        "description": "Underlying reason for the payment transaction, as published in an external purpose code list."
+                    },
+                    "categoryPurpose": {
+                        "enum": [
+                            "BONU",
+                            "CASH",
+                            "CBLK",
+                            "CCRD",
+                            "CORT",
+                            "DCRD",
+                            "DIVI",
+                            "DVPM",
+                            "FCOL",
+                            "GP2P",
+                            "GOVT",
+                            "HEDG",
+                            "INTC",
+                            "INTE",
+                            "LOAN",
+                            "MP2P",
+                            "OTHR",
+                            "PENS",
+                            "RRCT",
+                            "SALA",
+                            "SECU",
+                            "SSBE",
+                            "SUPP",
+                            "TAXS",
+                            "TRAD",
+                            "TREA",
+                            "VATX",
+                            "WHLD"
+                        ],
+                        "type": "string",
+                        "example": "INTC",
+                        "description": "Category purpose, in a proprietary form."
+                    },
+                    "remittanceInformation": {
+                        "$ref": "#/components/schemas/UnstructuredRemittanceInformationDtoV5"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "HttpValidationProblemDetails": {
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/ProblemDetails"
+                }],
+                "properties": {
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "additionalProperties": {}
+            },
+            "InstructionAmountDtoV5": {
+                "required": [
+                    "amount",
+                    "currency"
+                ],
+                "type": "object",
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "example": "18540.78",
+                        "format": "double"
+                    },
+                    "currency": {
+                        "minLength": 1,
+                        "example": "GBP",
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "description": "A number of monetary units specified in an active or a historic currency where the unit of currency is explicit and compliant with ISO 4217."
+            },
+            "PartyAddressDetailsDtoV5": {
+                "required": [
+                    "country",
+                    "postCode",
+                    "townName"
+                ],
+                "type": "object",
+                "properties": {
+                    "buildingNumber": {
+                        "maxLength": 16,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Number that identifies the position of a building on a street."
+                    },
+                    "buildingName": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of the building or house."
+                    },
+                    "streetName": {
+                        "maxLength": 70,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of a street or thoroughfare."
+                    },
+                    "townName": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of a built-up area, with defined boundaries, and a local government."
+                    },
+                    "country": {
+                        "minLength": 1,
+                        "pattern": "[A-Z]{2,2}",
+                        "type": "string",
+                        "description": "Nation with its own government."
+                    },
+                    "postCode": {
+                        "maxLength": 16,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PartyDetailsDtoV5": {
+                "required": [
+                    "name",
+                    "lei"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 140,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of the party"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/PartyAddressDetailsDtoV5"
+                    },
+                    "lei": {
+                        "pattern": "^[A-Z0-9]{18,18}[0-9]{2,2}$",
+                        "type": "string",
+                        "description": "Legal Entity Identifier of the party"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PaymentCreatedResponseDtoV5": {
+                "required": [
+                    "paymentId"
+                ],
+                "type": "object",
+                "properties": {
+                    "paymentId": {
+                        "type": "string",
+                        "description": "ClearBank identifier that uniquely identifies the new outbound/return payment instruction.",
+                        "format": "uuid"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ProblemDetails": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "detail": {
+                        "type": "string"
+                    },
+                    "instance": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": {}
+            },
+            "UnstructuredRemittanceInformationDtoV5": {
+                "type": "object",
+                "properties": {
+                    "creditorReferenceInformation": {
+                        "maxLength": 140,
+                        "minLength": 1,
+                        "type": "string",
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "description": "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+            }
+        }
+    }
+}

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -1,0 +1,669 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Send CHAPS payment",
+        "description": "Send CHAPS payment",
+        "version": "5.0.Chaps-payment"
+    },
+   "paths": {
+         "/payments/chaps/v5/customer-payments": {
+            "post": {
+                "tags": [
+                    "ExternalCustomerPaymentsV5"
+                ],
+                "description": "This endpoint will send a CHAPS customer payment (pacs.008).",
+                "operationId": "ExternalCreateCustomerPayment-v5",
+                "parameters": [
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_Authorization"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_DigitalSignature"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_RequestIdentifier"
+                  }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCustomerPaymentDtoV5"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCustomerPaymentDtoV5"
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCustomerPaymentDtoV5"
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCustomerPaymentDtoV5"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "parameters": {
+            "ParametersOpenapi_Authorization": {
+              "name": "Authorization",
+              "in": "header",
+              "description": "Your API token retrieved from the ClearBank portal.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_AuthorizationType"
+              }
+            },
+            "ParametersOpenapi_DigitalSignature": {
+              "name": "DigitalSignature",
+              "in": "header",
+              "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_DigitalSignatureType"
+              }
+            },
+            "ParametersOpenapi_RequestIdentifier": {
+              "name": "X-Request-Id",
+              "in": "header",
+              "description": "A unique identifier for the request.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_RequestIdentifierType"
+              }
+            }
+          },
+        "schemas": {
+            "ApiHeadersSchema_AuthorizationType": {
+                "description": "Authorization header restricted to Bearer token only",
+                "type": "string",
+                "pattern": "^Bearer +.+"
+            },
+            "ApiHeadersSchema_DigitalSignatureType": {
+                "description": "The digital signature generated by the API consumer",
+                "type": "string"
+            },
+            "ApiHeadersSchema_RequestIdentifierType": {
+                "description": "The request identifier supplied by the API consumer",
+                "type": "string"
+            },
+            "AccountIdentificationDtoV5": {
+                "type": "object",
+                "additionalProperties": false
+            },
+            "AccountIdentificationIbanDtoV5": {
+                "required": [
+                    "iban"
+                ],
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/AccountIdentificationDtoV5"
+                }],
+                "properties": {
+                    "iban": {
+                        "minLength": 1,
+                        "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
+                        "type": "string",
+                        "description": "International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer. Further specifications of the format and content of the IBAN can be found in the standard ISO 13616 \"Banking and related financial services - International Bank Account Number (IBAN)\" version 1997-10-01, or later revisions."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "AccountIdentificationOtherDtoV5": {
+                "required": [
+                    "identification",
+                    "schemeName"
+                ],
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/AccountIdentificationDtoV5"
+                }],
+                "properties": {
+                    "schemeName": {
+                        "enum": [
+                            "BBan",
+                            "Other"
+                        ],
+                        "type": "string",
+                        "example": "BBan",
+                        "description": "Scheme type. If this field is set to 'Other', then the proprietary field is required."
+                    },
+                    "proprietary": {
+                        "type": "string",
+                        "description": "This field must be present when schemeName is set to 'Other' and should not be present otherwise."
+                    },
+                    "identification": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Unambiguous identification for the given scheme (specified in schemeName). Set to either the BBAN (XXXX01020301234567) or the sort code and account number (01020301234567).",
+                        "example": "01020301234567"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "CreateCustomerPaymentDtoV5": {
+                "required": [
+                    "categoryPurpose",
+                    "creditor",
+                    "creditorAccount",
+                    "debtor",
+                    "debtorAccount",
+                    "endToEndIdentification",
+                    "instructedAmount",
+                    "instructionIdentification",
+                    "purpose",
+                    "sourceAccount"
+                ],
+                "type": "object",
+                "properties": {
+                    "instructionIdentification": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "example": "163f8yk55a9bb4w335qa5f",
+                        "description": "Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction.\\n\\nUsage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                    },
+                    "endToEndIdentification": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
+                        "type": "string",
+                        "example": "5850154964795488434534",
+                        "description": "Unique identification, as assigned by the initiating party, to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\n\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\n\nUsage: In case there are technical limitations to pass on multiple references, the end-to-end identification must be passed on throughout the entire end-to-end chain."
+                    },
+                    "instructedAmount": {
+                        "$ref": "#/components/schemas/InstructionAmountDtoV5"
+                    },
+                    "sourceAccount": {
+                        "type": "object",
+                        "oneOf": [{
+                                "$ref": "#/components/schemas/AccountIdentificationIbanDtoV5"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AccountIdentificationOtherDtoV5"
+                            }
+                        ],
+                        "description": "The ClearBank account that will be credited or debited based on the successful completion of the payment instruction."
+                    },
+                    "debtorAccount": {
+                        "type": "object",
+                        "oneOf": [{
+                                "$ref": "#/components/schemas/AccountIdentificationIbanDtoV5"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AccountIdentificationOtherDtoV5"
+                            }
+                        ],
+                        "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                    },
+                    "debtor": {
+                        "$ref": "#/components/schemas/CustomerPartyDetailsDtoV5"
+                    },
+                    "creditorAccount": {
+                        "type": "object",
+                        "oneOf": [{
+                                "$ref": "#/components/schemas/AccountIdentificationIbanDtoV5"
+                            },
+                            {
+                                "$ref": "#/components/schemas/AccountIdentificationOtherDtoV5"
+                            }
+                        ],
+                        "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                    },
+                    "creditor": {
+                        "$ref": "#/components/schemas/CustomerPartyDetailsDtoV5"
+                    },
+                    "purpose": {
+                        "enum": [
+                            "BKFE",
+                            "BKIP",
+                            "BKPP",
+                            "CBLK",
+                            "ACCT",
+                            "CASH",
+                            "COLL",
+                            "CSDB",
+                            "DEPT",
+                            "INTC",
+                            "INTP",
+                            "LIMA",
+                            "NETT",
+                            "EXTD",
+                            "OTCD",
+                            "REPO",
+                            "SBSC",
+                            "SLEB",
+                            "AGRT",
+                            "AREN",
+                            "BEXP",
+                            "BOCE",
+                            "COMC",
+                            "CPYR",
+                            "GDSV",
+                            "GSCB",
+                            "LICF",
+                            "ROYA",
+                            "SERV",
+                            "SUBS",
+                            "SUPP",
+                            "TRAD",
+                            "CHAR",
+                            "COMT",
+                            "ECPR",
+                            "EPAY",
+                            "CLPR",
+                            "COMP",
+                            "DBTC",
+                            "HLRP",
+                            "HLST",
+                            "INPC",
+                            "INPR",
+                            "INSC",
+                            "INSU",
+                            "INTE",
+                            "LBRI",
+                            "LIFI",
+                            "LOAN",
+                            "LOAR",
+                            "PENO",
+                            "PPTI",
+                            "RELG",
+                            "TRFD",
+                            "FORW",
+                            "FXNT",
+                            "BLDM",
+                            "BNET",
+                            "CDBL",
+                            "CORT",
+                            "CPKC",
+                            "EDUC",
+                            "FAND",
+                            "FEES",
+                            "GIFT",
+                            "GOVT",
+                            "INSM",
+                            "IVPT",
+                            "REBT",
+                            "REFU",
+                            "RENT",
+                            "REOD",
+                            "TCSC",
+                            "CMDT",
+                            "DERI",
+                            "DIVD",
+                            "FREX",
+                            "HEDG",
+                            "INVS",
+                            "SAVG",
+                            "SECU",
+                            "TREA",
+                            "FNET",
+                            "FUTR",
+                            "DNTS",
+                            "HLTI",
+                            "LTCF",
+                            "MDCS",
+                            "VIEW",
+                            "SWFP",
+                            "SWPP",
+                            "SWRS",
+                            "SWUF",
+                            "ADCS",
+                            "ALMY",
+                            "BECH",
+                            "BENE",
+                            "BONU",
+                            "COMM",
+                            "HREC",
+                            "PEFC",
+                            "PENS",
+                            "SALA",
+                            "SSBE",
+                            "LREB",
+                            "LREV",
+                            "ESTX",
+                            "HSTX",
+                            "INTX",
+                            "PTXP",
+                            "RDTX",
+                            "TAXS",
+                            "VATX",
+                            "WHLD",
+                            "TAXR",
+                            "CBTV",
+                            "ELEC",
+                            "GASB",
+                            "PHON",
+                            "UBIL",
+                            "WTER",
+                            "GAMB",
+                            "LOTT",
+                            "PCOM",
+                            "PDEP",
+                            "PLDS",
+                            "PLRF"
+                        ],
+                        "type": "string",
+                        "example": "LOAN",
+                        "description": "Underlying reason for the payment transaction, as published in an external purpose code list."
+                    },
+                    "categoryPurpose": {
+                        "enum": [
+                            "BONU",
+                            "CASH",
+                            "CBLK",
+                            "CCRD",
+                            "CORT",
+                            "DCRD",
+                            "DIVI",
+                            "DVPM",
+                            "FCOL",
+                            "GP2P",
+                            "GOVT",
+                            "HEDG",
+                            "INTC",
+                            "INTE",
+                            "LOAN",
+                            "MP2P",
+                            "OTHR",
+                            "PENS",
+                            "RRCT",
+                            "SALA",
+                            "SECU",
+                            "SSBE",
+                            "SUPP",
+                            "TAXS",
+                            "TRAD",
+                            "TREA",
+                            "VATX",
+                            "WHLD"
+                        ],
+                        "type": "string",
+                        "example": "LOAN",
+                        "description": "Category purpose, in a proprietary form."
+                    },
+                    "remittanceInformation": {
+                        "$ref": "#/components/schemas/StructuredRemittanceInformationDtoV5"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "CustomerPartyDetailsDtoV5": {
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "minLength": 1,
+                        "type": "string",
+                        "description": "Name of the party"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/PartyAddressDetailsDtoV5"
+                    },
+                    "organisationIdentifier": {
+                        "$ref": "#/components/schemas/OrganisationIdentifierV5"
+                    },
+                    "privateIdentifier": {
+                        "$ref": "#/components/schemas/PrivateIdentifierV5"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "HttpValidationProblemDetails": {
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/ProblemDetails"
+                }],
+                "properties": {
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "additionalProperties": {}
+            },
+            "InstructionAmountDtoV5": {
+                "required": [
+                    "amount",
+                    "currency"
+                ],
+                "type": "object",
+                "properties": {
+                    "amount": {
+                        "type": "number",
+                        "example": "1477.85",
+                        "format": "double"
+                    },
+                    "currency": {
+                        "minLength": 1,
+                        "example": "GBP",
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": false,
+                "description": "A number of monetary units specified in an active or a historic currency where the unit of currency is explicit and compliant with ISO 4217."
+            },
+            "OrganisationIdentifierV5": {
+                "type": "object",
+                "properties": {
+                    "bic": {
+                        "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3})$",
+                        "type": "string",
+                        "description": "BIC of the entity"
+                    },
+                    "lei": {
+                        "pattern": "^[A-Z0-9]{18,18}[0-9]{2,2}$",
+                        "type": "string",
+                        "example": "646700J3LMYRBDP9MA86",
+                        "description": "Legal Entity Identifier of the entity"
+                    },
+                    "otherIdentification": {
+                        "maxLength": 35,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
+                        "type": "string",
+                        "description": "Corporate share Companies House identifier with us"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PartyAddressDetailsDtoV5": {
+                "required": [
+                    "country",
+                    "postCode",
+                    "townName"
+                ],
+                "type": "object",
+                "properties": {
+                    "buildingNumber": {
+                        "maxLength": 16,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Number that identifies the position of a building on a street."
+                    },
+                    "buildingName": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of the building or house."
+                    },
+                    "streetName": {
+                        "maxLength": 70,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of a street or thoroughfare."
+                    },
+                    "townName": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of a built-up area, with defined boundaries, and a local government."
+                    },
+                    "country": {
+                        "minLength": 1,
+                        "pattern": "[A-Z]{2,2}",
+                        "type": "string",
+                        "description": "Nation with its own government."
+                    },
+                    "postCode": {
+                        "maxLength": 16,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PartyDetailsDtoV5": {
+                "required": [
+                    "name"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 140,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of the party"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/PartyAddressDetailsDtoV5"
+                    },
+                    "lei": {
+                        "pattern": "^[A-Z0-9]{18,18}[0-9]{2,2}$",
+                        "type": "string",
+                        "description": "Legal Entity Identifier of the party"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PaymentCreatedResponseDtoV5": {
+                "required": [
+                    "paymentId"
+                ],
+                "type": "object",
+                "properties": {
+                    "paymentId": {
+                        "type": "string",
+                        "description": "ClearBank identifier that uniquely identifies the new outbound/return payment instruction.",
+                        "format": "uuid"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "PrivateIdentifierV5": {
+                "type": "object",
+                "properties": {
+                    "otherIdentification": {
+                        "maxLength": 35,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
+                        "type": "string",
+                        "description": "Personal identifier"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ProblemDetails": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "detail": {
+                        "type": "string"
+                    },
+                    "instance": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": {}
+            },
+            "StructuredRemittanceInformationDtoV5": {
+                "type": "object",
+                "properties": {
+                    "creditorReferenceInformation": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "example": "ACC88451775LOAN",
+                        "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                    }
+                },
+                "additionalProperties": false,
+                "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+            }
+        }
+    }
+}

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -536,6 +536,7 @@
             },
             "OrganisationIdentifierV5": {
                 "type": "object",
+                "description": "Option to provide either OrganisationIdentifier or PrivateIdentifier, but not both.",
                 "properties": {
                     "bic": {
                         "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3})$",
@@ -649,6 +650,7 @@
             },
             "PrivateIdentifierV5": {
                 "type": "object",
+                "description": "Option to provide either OrganisationIdentifier or PrivateIdentifier, but not both.",
                 "properties": {
                     "otherIdentification": {
                         "maxLength": 35,

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -180,6 +180,9 @@
                         "description": "Scheme type. If this field is set to 'Other', then the proprietary field is required."
                     },
                     "proprietary": {
+                        "enum": [
+                            "SortcodeAccountNumber"
+                        ],
                         "type": "string",
                         "description": "This field must be present when schemeName is set to 'Other' and should not be present otherwise."
                     },
@@ -213,7 +216,7 @@
                         "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
                         "type": "string",
                         "example": "163f8yk55a9bb4w335qa5f",
-                        "description": "Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction.\\n\\nUsage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                        "description": "Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction. Usage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
                     },
                     "endToEndIdentification": {
                         "maxLength": 35,
@@ -249,7 +252,7 @@
                         "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
                     },
                     "debtor": {
-                        "$ref": "#/components/schemas/CustomerPartyDetailsDtoV5"
+                        "$ref": "#/components/schemas/DebtorCustomerPartyDetailsDtoV5"
                     },
                     "creditorAccount": {
                         "type": "object",
@@ -263,7 +266,7 @@
                         "description": "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
                     },
                     "creditor": {
-                        "$ref": "#/components/schemas/CustomerPartyDetailsDtoV5"
+                        "$ref": "#/components/schemas/CreditorCustomerPartyDetailsDtoV5"
                     },
                     "purpose": {
                         "enum": [
@@ -440,14 +443,42 @@
                 },
                 "additionalProperties": false
             },
-            "CustomerPartyDetailsDtoV5": {
+            "DebtorCustomerPartyDetailsDtoV5": {
+                "required": [
+                    "name",
+                    "postalAddress"
+                ],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "maxLength": 140,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Name of the party"
+                    },
+                    "postalAddress": {
+                        "$ref": "#/components/schemas/PartyAddressDetailsDtoV5"
+                    },
+                    "organisationIdentifier": {
+                        "$ref": "#/components/schemas/OrganisationIdentifierV5"
+                    },
+                    "privateIdentifier": {
+                        "$ref": "#/components/schemas/PrivateIdentifierV5"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "CreditorCustomerPartyDetailsDtoV5": {
                 "required": [
                     "name"
                 ],
                 "type": "object",
                 "properties": {
                     "name": {
+                        "maxLength": 140,
                         "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
                         "type": "string",
                         "description": "Name of the party"
                     },
@@ -496,7 +527,8 @@
                     "currency": {
                         "minLength": 1,
                         "example": "GBP",
-                        "type": "string"
+                        "type": "string",
+                        "description": "Set to 'GBP' as other currencies are not supported."
                     }
                 },
                 "additionalProperties": false,

--- a/data/endpoints/chaps-return-v5.json
+++ b/data/endpoints/chaps-return-v5.json
@@ -1,0 +1,326 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "ClearBank.Chaps.RtgsPortalManager.Container",
+      "version": "5.0-ChapsReturn"
+    },
+    "paths": {
+        "/payments/chaps/v5/return-payments": {
+            "post": {
+                "tags": [
+                    "ExternalReturnPaymentsV5"
+                ],
+                "description": "Return a CHAPS payment. All CHAPS returns must be made by the next working day. The same operating hours apply for CHAPS returns as for regular CHAPS payments. Note that this endpoint only supports returning CHAPS payments made after the Bank of England's RTGS Renewal Programme went live (all payments made on or after 19 June 2023).",
+                "operationId": "ExternalReturnPayment-v5",
+                "parameters": [
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_Authorization"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_DigitalSignature"
+                  },
+                  {
+                    "$ref": "#/components/parameters/ParametersOpenapi_RequestIdentifier"
+                  }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json-patch+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateReturnPaymentDtoV5"
+                            }
+                        },
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateReturnPaymentDtoV5"
+                            }
+                        },
+                        "text/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateReturnPaymentDtoV5"
+                            }
+                        },
+                        "application/*+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateReturnPaymentDtoV5"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaymentCreatedResponseDtoV5"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                        }
+                                },
+                            "application/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                }
+                            },
+                            "text/json": {
+                                "schema": {
+                                            "$ref": "#/components/schemas/ProblemDetails"
+                                        }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+    "components": {
+      "parameters": {
+            "ParametersOpenapi_Authorization": {
+              "name": "Authorization",
+              "in": "header",
+              "description": "Your API token retrieved from the ClearBank portal.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_AuthorizationType"
+              }
+            },
+            "ParametersOpenapi_DigitalSignature": {
+              "name": "DigitalSignature",
+              "in": "header",
+              "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_DigitalSignatureType"
+              }
+            },
+            "ParametersOpenapi_RequestIdentifier": {
+              "name": "X-Request-Id",
+              "in": "header",
+              "description": "A unique identifier for the request.",
+              "required": true,
+              "schema": {
+                "$ref": "#/components/schemas/ApiHeadersSchema_RequestIdentifierType"
+              }
+            }
+          },
+        "schemas": {
+          "ApiHeadersSchema_AuthorizationType": {
+                "description": "Authorization header restricted to Bearer token only",
+                "type": "string",
+                "pattern": "^Bearer +.+"
+            },
+            "ApiHeadersSchema_DigitalSignatureType": {
+                "description": "The digital signature generated by the API consumer",
+                "type": "string"
+            },
+            "ApiHeadersSchema_RequestIdentifierType": {
+                "description": "The request identifier supplied by the API consumer",
+                "type": "string"
+            },
+            "CreateReturnPaymentDtoV5": {
+                "required": [
+                    "instructionIdentification",
+                    "paymentId",
+                    "reason"
+                ],
+                "type": "object",
+                "properties": {
+                    "paymentId": {
+                        "type": "string",
+                        "description": "ClearBank identifier that uniquely identifies the inbound payment instruction.",
+                        "format": "uuid",
+                        "example": "bd382f05e8fa4056b25e531e561"
+                    },
+                    "reason": {
+                        "enum": [
+                            "AM09",
+                            "BE01",
+                            "BE04",
+                            "BE05",
+                            "BE06",
+                            "FOCR",
+                            "MD06",
+                            "MS02",
+                            "CURR",
+                            "AC04",
+                            "AM02",
+                            "AM03",
+                            "AG01",
+                            "RR04",
+                            "AC01",
+                            "AC02",
+                            "AC03",
+                            "AC06",
+                            "AC07",
+                            "AC13",
+                            "AC14",
+                            "AC15",
+                            "AC16",
+                            "AC17",
+                            "AG02",
+                            "AG07",
+                            "AGNT",
+                            "AM01",
+                            "AM04",
+                            "AM05",
+                            "AM06",
+                            "AM07",
+                            "AM10",
+                            "ARDT",
+                            "BE07",
+                            "BE08",
+                            "BE10",
+                            "BE11",
+                            "BE16",
+                            "BE17",
+                            "CN01",
+                            "CNOR",
+                            "CNPC",
+                            "CUST",
+                            "DNOR",
+                            "DS28",
+                            "DT01",
+                            "DT02",
+                            "ED01",
+                            "ED03",
+                            "ED05",
+                            "EMVL",
+                            "ERIN",
+                            "FF03",
+                            "FF04",
+                            "FF05",
+                            "FF06",
+                            "FF07",
+                            "FR01",
+                            "FRTR",
+                            "G004",
+                            "MD01",
+                            "MD02",
+                            "MD05",
+                            "MD07",
+                            "MS03",
+                            "NARR",
+                            "NOAS",
+                            "NOCM",
+                            "NOOR",
+                            "PINL",
+                            "RC01",
+                            "RC07",
+                            "RC08",
+                            "RC11",
+                            "RF01",
+                            "RR01",
+                            "RR02",
+                            "RR03",
+                            "RR05",
+                            "RR06",
+                            "RR07",
+                            "RR08",
+                            "RR09",
+                            "RR11",
+                            "RR12",
+                            "RUTA",
+                            "SL01",
+                            "SL02",
+                            "SL11",
+                            "SL12",
+                            "SL13",
+                            "SL14",
+                            "SP01",
+                            "SP02",
+                            "SVNR",
+                            "TM01",
+                            "TRAC",
+                            "UPAY"
+                        ],
+                        "type": "string",
+                        "example": "AC04",
+                        "description": "Specifies the reason for the return."
+                    },
+                    "instructionIdentification": {
+                        "maxLength": 35,
+                        "minLength": 1,
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
+                        "type": "string",
+                        "description": "Unique identification, as assigned by an instructing party for an instructed party, to unambiguously identify the instruction.\n\nUsage: The instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                    }
+                },
+                "additionalProperties": false
+            },
+            "HttpValidationProblemDetails": {
+                "type": "object",
+                "allOf": [{
+                    "$ref": "#/components/schemas/ProblemDetails"
+                }],
+                "properties": {
+                    "errors": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "additionalProperties": {}
+            },
+            "PaymentCreatedResponseDtoV5": {
+                "required": [
+                    "paymentId"
+                ],
+                "type": "object",
+                "properties": {
+                    "paymentId": {
+                        "type": "string",
+                        "description": "ClearBank identifier that uniquely identifies the new outbound/return payment instruction.",
+                        "format": "uuid"
+                    }
+                },
+                "additionalProperties": false
+            },
+            "ProblemDetails": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string"
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "detail": {
+                        "type": "string"
+                    },
+                    "instance": {
+                        "type": "string"
+                    }
+                },
+                "additionalProperties": {}
+            }
+        }
+    }
+}

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -715,6 +715,7 @@
     },
     "OrganisationIdentifierV5": {
         "type": "object",
+        "description": "Option to provide either OrganisationIdentifier or PrivateIdentifier, but not both.",
         "properties": {
             "bic": {
                 "pattern": "^[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3})$",
@@ -858,6 +859,7 @@
     },
     "PrivateIdentifierV5": {
         "type": "object",
+        "description": "Option to provide either OrganisationIdentifier or PrivateIdentifier, but not both.",
         "properties": {
             "otherIdentification": {
                 "maxLength": 35,


### PR DESCRIPTION
Add the following endpoints:
- /payments/chaps/v5/customer-payments
- /payments/chaps/v5/institution-payments
- /payments/chaps/v5/return-payments

Add object description in /payments/cross-border-sterling/v3/payments (documentation fix only)