### PR TITLE
Add Embedded Banking docs for GET and PATCH endpoints

### DIFF
--- a/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
+++ b/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
@@ -59,7 +59,7 @@ You can amend the details or the status of a cash ISA using the [PATCH /v1/accou
 To retrieve end of day balances for a cash ISA, use the [camt.053 endpoints](../gbp-accounts/account-reporting#statements).
 
 <Callout colour="blue">
-The endpoints for retrieving all ISAs and amending cash ISA details or status are the same as the one for for real accounts.
+The endpoints for retrieving all ISAs and amending cash ISA details or status are the same as those used for real accounts.
 </Callout>
 
 ### End of life for a cash ISA

--- a/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
+++ b/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
@@ -52,7 +52,15 @@ The process is shown in this message flow diagram:
 
 ![Submit the POST /v1/isas endpoint. Once you receive a 201 response, submit the PUT /v1/accounts/{accountId}/nominated-account to set a nominated account. Once you receive a 200 response, funds can now be added to the cash ISA.](/assets/images/cash-isa-open.svg)
 
-The account is now open and fully operational. You can return details of a cash ISA using the [GET /v1/isas/{accountId}](#get-cash-isa-details) endpoint.
+The account is now open and fully operational. You can retrieve information on all ISAs by using the [GET /v3/accounts](#get-all-accounts-real) endpoint and filtering for ISAs. You can also retrieve details on a specific cash ISA using the [GET /v1/isas/{accountId}](#get-cash-isa-details) endpoint.
+
+To retrieve end of day balances for a cash ISA, use the [camt.053 endpoints](../gbp-accounts/account-reporting#statements).
+
+You can amend the details or the status of a cash ISA using the [PATCH /v1/accounts/{accountId}](#amend-cash-isa-details-or-status) endpoint.
+
+<Callout colour="blue">
+The endpoints for retrieving all ISAs and amending cash ISA details or status are the same as the one for for real accounts.
+</Callout>
 
 ### End of life for a cash ISA
 
@@ -119,7 +127,7 @@ The process is shown in this message flow diagram:
 
 #### Discontinue
 
-The process to discontinue a cash ISA account begins with the notification that the account holder is deceased. Once you have received the notification, use the [PATCH /v1/accounts/{accountId}](#amend-a-cash-isa-status) to update the `status` to `Suspended` using the `statusReason`  of `AccountHolderDeceased`.  
+The process to discontinue a cash ISA account begins with the notification that the account holder is deceased. Once you have received the notification, use the [PATCH /v1/accounts/{accountId}](#amend-cash-isa-details-or-status) to update the `status` to `Suspended` using the `statusReason`  of `AccountHolderDeceased`.  
 
 As per HMRC rules, if an ISA investor passes away, their account must be treated as **'continuing account of a deceased investor'**. This allows the account to continue to accrue interest and benefit from the tax advantages of an ISA for the period beginning with the death of the account holder and ending either:
 
@@ -187,11 +195,22 @@ The process is shown in this flow diagram:
 
 <EndpointBlock
   type="patch"
-  title="Amend a cash ISA status"
+  title="Amend cash ISA details or status"
   endpoints={[
     {
       path: "/v1/accounts/{accountId}",
-      version: "1.0.Sterling",
+      version: "1.0.Sterling"
+    }
+  ]}
+/>
+
+<EndpointBlock
+  type="get"
+  title="Get all real accounts, including cash ISAs"
+  endpoints={[
+    {
+      path: "/v3/Accounts",
+      version: "3.0.Sterling",
     }
   ]}
 />

--- a/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
+++ b/content/uk/docs/embedded-banking/flexible-cash-isa.mdx
@@ -54,9 +54,9 @@ The process is shown in this message flow diagram:
 
 The account is now open and fully operational. You can retrieve information on all ISAs by using the [GET /v3/accounts](#get-all-accounts-real) endpoint and filtering for ISAs. You can also retrieve details on a specific cash ISA using the [GET /v1/isas/{accountId}](#get-cash-isa-details) endpoint.
 
-To retrieve end of day balances for a cash ISA, use the [camt.053 endpoints](../gbp-accounts/account-reporting#statements).
-
 You can amend the details or the status of a cash ISA using the [PATCH /v1/accounts/{accountId}](#amend-cash-isa-details-or-status) endpoint.
+
+To retrieve end of day balances for a cash ISA, use the [camt.053 endpoints](../gbp-accounts/account-reporting#statements).
 
 <Callout colour="blue">
 The endpoints for retrieving all ISAs and amending cash ISA details or status are the same as the one for for real accounts.

--- a/content/uk/docs/embedded-banking/savings-accounts.mdx
+++ b/content/uk/docs/embedded-banking/savings-accounts.mdx
@@ -32,6 +32,16 @@ Always note down the X-Request-Id when creating an account. If you receive a 500
 
 Once you have opened a savings account, you can deposit and withdraw payments using the Faster Payments or CHAPS payment endpoints. Incoming or outgoing Bacs payments are not accepted.
 
+You can retrieve information on all savings accounts by using the [GET /v3/accounts](#get-all-real-accounts-including-savings-accounts) endpoint and filtering for savings accounts, or retrieve information for a specific savings account through the [GET /v3/Accounts/{accountId}](#get-information-for-a-savings-account) endpoint.
+
+You can amend a savings account with the [PATCH /v1/accounts/{accountId}](#amend-a-savings-account) endpoint.
+
+To retrieve end of day balances for a savings account, use the [camt.053 endpoints](../gbp-accounts/account-reporting#statements).
+
+<Callout colour="blue">
+These are the same endpoints used to retrieve and amend information on real accounts.
+</Callout>
+
 **To close a savings account:**
 1. Withdraw all funds from the account.
 2. Verify that a nominated account has been defined. You can obtain details of the currently configured nominated account using the [GET /v1/accounts/{accountId}/nominated-account](#get-a-nominated-account) endpoint.
@@ -112,6 +122,39 @@ If account closure fails and hasn't been resolved by the end of the month, then 
 />
 
 <WebhookPlaceholder render='interest-paid-webhook-v1' />
+
+<EndpointBlock
+  type="get"
+  title="Get all real accounts, including savings accounts"
+  endpoints={[
+    {
+      path: "/v3/Accounts",
+      version: "3.0.Sterling"
+    }
+  ]}
+/>
+
+<EndpointBlock
+  type="get"
+  title="Get information for a savings account"
+  endpoints={[
+    {
+      path: "/v3/Accounts/{accountId}",
+      version: "3.0.Sterling"
+    }
+  ]}
+/>
+
+<EndpointBlock
+  type="patch"
+  title="Amend a savings account"
+  endpoints={[
+    {
+      path: "/v1/accounts/{accountId}",
+      version: "1.0.Sterling"
+    }
+  ]}
+/>
 
 <EndpointBlock
   type="post"

--- a/data/endpoints/sterling-v3.json
+++ b/data/endpoints/sterling-v3.json
@@ -678,7 +678,7 @@
           "name": {
             "type": "string",
             "description": "The friendly name of the account.",
-            "example": "Current Account"
+            "example": "Sample Account Type Name"
           },
           "label": {
             "type": "string",


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Add information on account retrieval/patching to cash ISA and Savings pages
 - Both:
     - `GET /v3/Accounts`
   - `PATCH /v1/accounts/{accountId}`
 - Savings only:
   - `GET /v3/Accounts/{accountId}`

Changed example on endpoint to make it more appropriate for all account types