### PR TITLE
Add VSCode snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ secret.auto.tfvars
 
 # Visual Studio
 .vs
-.vscode
 
 # coverage
 coverage

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "npm run start",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run",
+                "start"
+            ],
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/mdx-snippets.code-snippets
+++ b/.vscode/mdx-snippets.code-snippets
@@ -74,5 +74,5 @@
 			"$0"
 			],
 		"description": "Add a callout block for emphasising something critical to the reader."
-	},
+	}
 }

--- a/.vscode/mdx-snippets.code-snippets
+++ b/.vscode/mdx-snippets.code-snippets
@@ -1,0 +1,78 @@
+{
+	"Create MDX page": {
+		"prefix": "newPage",
+		"body": [
+		  "---",
+		  "title: \"$1\"",
+		  "order: ${2|0,1,2,3,4,5,6,7,8,9,10|}",
+		  "metaTitle: \"${3:tab-title}\"",
+		  "metaDescription: \"${4:shared-url-preview-text}\"",
+		  "showPageMenu: ${5|true,false|}",
+		  "---",
+		  "",
+		  "${6| ,import Callout from \"src/components/callout\";|}",
+		  "${7| ,import EndpointBlock from \"src/components/endpoint-block\";|}",
+		  "${8| ,import WebhookSummary from \"src/components/webhook-summary\";|}",
+		  "${9| ,import WebhookPlaceholder from \"src/components/webhook-placeholder\";|}",
+		  "",
+		  "## ${1:opening-header}",
+		  "",
+		  "$0"
+		],
+		"description": "Create a new MDX page with front matter and optional imports"
+	},
+	"Create endpoint block": {
+		"prefix": "newEndpoint",
+		"body": [
+			"<EndpointBlock",
+			"  type=\"${1|post,get,patch,put,delete|}\"",
+			"  title=\"$2\"",
+			"  endpoints={[",
+			"    {",
+			"      path: \"$3\",",
+			"      version: \"$4\"",
+			"    }",
+			"  ]}",
+			"/>",
+			"",
+			"$0"
+			],
+		"description": ""
+	},
+	"Create webhook summary block": {
+		"prefix": "newWebhookSummary",
+		"body": [
+			"<WebhookSummary",
+			"  description='$1'",
+			"  endpoint='$2'",
+			"  method='${3|post,get,patch,put,delete|}'",
+			"  webhooks={[",
+			"    '$4'",
+			"  ]}",
+			"/>",
+			"",
+			"$0"
+			],
+		"description": "Add a webhook summary block."
+	},
+	"Create webhook placeholder": {
+		"prefix": "newPlaceholderWebhook",
+		"body": [
+			"<WebhookPlaceholder render='${1:full-webhook-name-created-v1}' />",
+			"",
+			"$0"
+			],
+		"description": "Add a webhook placeholder. Use the empty field to set the appropriate webhook."
+	},
+	"Create callout block": {
+		"prefix": "newCallout",
+		"body": [
+			"<Callout colour=\"blue\">",
+			"  ${1:callout-text}",
+			"</Callout>",
+			"",
+			"$0"
+			],
+		"description": "Add a callout block for emphasising something critical to the reader."
+	},
+}


### PR DESCRIPTION
Update to Technical Author tooling only, no change to API functionality or documentation.
* Added VSCode snippets for the following blocks:
  * newPage - create front matter and imports for .mdx content page
  * newEndpoint - create endpoint block
  * newCallout - create callout block
  * newWebhookSummary - create a summary block for several endpoints
  * newWebhookPlaceholder - create a webhook placeholder entry

 * Added launch.json to enable use of built-in VSCode's run/debug function (ctrl+F5/F5) 
