### PR TITLE
GBP accounts and savings - relax OwnerName allowed characters

### DIFF
--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7540,7 +7540,7 @@
           },
           "ownerName": {
             "maxLength": 140,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[0-9a-zA-Z\\/\\-\\?:\\(\\)\\.,’'\\+ !#$%&\\*=^_`\\{\\|\\}~\"\";<>@\\[\\\\\\]]+$",
             "type": "string",
             "description": "The name used to identify the legal owner of the nominated account.",
@@ -7856,7 +7856,7 @@
         "properties": {
           "ownerName": {
             "maxLength": 140,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the account.",

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7487,7 +7487,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 0,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the account.",
             "example": "John Smith"
@@ -7541,7 +7541,7 @@
           "ownerName": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[0-9a-zA-Z\/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\"\";<>@\\[\\\\]]+$",
+            "pattern": "^[0-9a-zA-Z\\/\\-\\?:\\(\\)\\.,’'\\+ !#$%&\\*=^_`\\{\\|\\}~\"\";<>@\\[\\\\\\]]+$",
             "type": "string",
             "description": "The name used to identify the legal owner of the nominated account.",
             "example": "John Smith"
@@ -7857,7 +7857,7 @@
           "ownerName": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the account.",
             "example": "John Smith"
@@ -7969,7 +7969,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 0,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the virtual account.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3581,7 +3581,7 @@
           "ownerName": {
             "maxLength": 70,
             "minLength": 1,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "Virtual account owner name (account holder label).",
             "example": "John Smith"

--- a/data/endpoints/sterling-v3.json
+++ b/data/endpoints/sterling-v3.json
@@ -633,7 +633,7 @@
           "name": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "Name by which a party is known and which is usually used to identify that party.",
             "example": "John Smith"

--- a/data/endpoints/sterling-v3.json
+++ b/data/endpoints/sterling-v3.json
@@ -632,7 +632,7 @@
         "properties": {
           "name": {
             "maxLength": 140,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "Name by which a party is known and which is usually used to identify that party.",

--- a/data/endpoints/sterling-v4.json
+++ b/data/endpoints/sterling-v4.json
@@ -320,7 +320,7 @@
           "name": {
             "maxLength": 140,
             "minLength": 0,
-            "pattern": "^[\\p{L}0-9@#;:\\-?().,+=!\"\"%*{}/'&\\s]*$",
+            "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "Name for the owner of the current account.",
             "example": "John Smith"


### PR DESCRIPTION
Relaxing pattern requirements in the following account endpoints:

- POST /v3/accounts
- POST /v4/accounts
- POST /v2/accounts/{accountId}/virtual
- PATCH /v1/accounts/{accountId}/virtual/{virtualAccountId}
- PATCH /v1/accounts/{accountId}
- POST /v1/savings
- PUT /v1/accounts/{accountId}/nominated-account