### PR TITLE
SCT relax postal address fields for payments

### DIFF
--- a/data/endpoints/sepa-ct-v1.json
+++ b/data/endpoints/sepa-ct-v1.json
@@ -366,8 +366,7 @@
             "Creditor": {
                 "required": [
                     "accountIban",
-                    "name",
-                    "postalAddress"
+                    "name"
                 ],
                 "type": "object",
                 "properties": {
@@ -437,8 +436,7 @@
             "Debtor": {
                 "required": [
                     "accountIban",
-                    "name",
-                    "postalAddress"
+                    "name"
                 ],
                 "type": "object",
                 "properties": {
@@ -497,7 +495,7 @@
             "PostalAddress": {
                 "required": [
                     "country",
-                    "streetName"
+                    "townName"
                 ],
                 "type": "object",
                 "properties": {

--- a/data/endpoints/sepa-instant-emulator-v1.json
+++ b/data/endpoints/sepa-instant-emulator-v1.json
@@ -476,6 +476,7 @@
         "additionalProperties": false
       },
       "PostalAddress": {
+        "required": ["Country","TownName"],
         "type": "object",
         "properties": {
           "StreetName": {

--- a/data/endpoints/sepa-instant-v1.json
+++ b/data/endpoints/sepa-instant-v1.json
@@ -599,6 +599,7 @@
         }
       },
       "PostalAddress": {
+        "required": ["country", "townName"],
         "type": "object",
         "properties": {
           "streetName": {


### PR DESCRIPTION
Update the **POST /payments/sepa-ct/v1/customer-payments** endpoint so that the `Creditor` and `Debtor` fields no longer require a PostalAddress.  
If a PostalAddress is provided, then the `Country` and `TownName` must be provided.

The `Country` _and_ `TownName` fields were already mandatory, this change corrects the documentation for SCT and SCT Inst to align with the implementation.