### PR TITLE
Dev Portal fix header colours

### DIFF
--- a/src/components/mdxComponents/mdx-components.styles.ts
+++ b/src/components/mdxComponents/mdx-components.styles.ts
@@ -11,9 +11,10 @@ export const Header = styled(Text)`
   font-family: ${fonts.heading};
   font-weight: 600;
   scroll-margin-top: ${heights.header};
+  color: ${colors.businessBlue};
 `
 
-// TODO: This style doesn't exisit in the styleguide and needs sorting out properly
+// TODO: This style doesn't exist in the styleguide and needs sorting out properly
 export const H1 = styled(Header)`
   margin-top: 40px;
   font-family: ${fonts.body};


### PR DESCRIPTION
Update to site CSS only, no change to documentation or API functionality.
* Update HEADER style to all be black
* H4, H5, H6 now render black instead of navy