### PR TITLE
T2 add pre-existing nonIban field for Pacs.008

### DIFF
--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -487,7 +487,7 @@
                         "maxLength": 34,
                         "minLength": 1,
                         "nullable": true,
-                        "description": "Non-IBAN account identifier."
+                        "description": "Non-IBAN account identifier - to be used when IBAN is not available for the creditor."
                     }
                 },
                 "additionalProperties": false

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -346,8 +346,12 @@
                         "description": "The name and, optionally, the legal entity identifier of the account."
                     },
                     "creditorAccount": {
-                        "$ref": "#/components/schemas/CustomerPayments.IbanAccount",
-                        "description": "Information about the creditor account in a given transaction."
+                        "$ref": "#/components/schemas/IbanOrOtherAccount",
+                        "description": "The creditor's bank account number. You must provide a value for the Iban OR the nonIban field."
+                    },
+                    "creditorAgent": {
+                        "$ref": "#/components/schemas/CustomerPayments.CreditorAgent",
+                        "description": "Information that identifies the creditor agent as a financial institution."
                     },
                     "debtor": {
                         "$ref": "#/components/schemas/CustomerPayments.PartyInformation",
@@ -356,10 +360,6 @@
                     "debtorAccount": {
                         "$ref": "#/components/schemas/CustomerPayments.IbanAccount",
                         "description": "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
-                    },
-                    "creditorAgent": {
-                        "$ref": "#/components/schemas/CustomerPayments.CreditorAgent",
-                        "description": "Information that identifies the creditor agent as a financial institution."
                     },
                     "endToEndIdentification": {
                         "description": "Unique identification, as assigned by the initiating party, to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.",
@@ -471,6 +471,27 @@
                 },
                 "additionalProperties": false
             },
+            "IbanOrOtherAccount": {
+                "type": "object",
+                "properties": {
+                    "iban": {
+                        "maxLength": 34,
+                        "minLength": 5,
+                        "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
+                        "type": "string",
+                        "description": "International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer.\r\nFurther specifications of the format and content of the IBAN can be found in the standard ISO 13616 \"Banking and related financial services - International Bank Account Number (IBAN)\" version 1997-10-01, or later revisions."
+                    },
+                    "nonIban": {
+                        "type": "string",
+                        "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+](|[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+]|[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]{1,32}[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+])\\z",
+                        "maxLength": 34,
+                        "minLength": 1,
+                        "nullable": true,
+                        "description": "Non-IBAN account identifier."
+                    }
+                },
+                "additionalProperties": false
+            },
             "CustomerPayments.IbanAccount": {
                 "required": [
                     "iban"
@@ -483,12 +504,7 @@
                         "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
                         "type": "string",
                         "description": "International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer. Further specifications of the format and content of the IBAN can be found in the standard ISO 13616 \"Banking and related financial services - International Bank Account Number (IBAN)\" version 1997-10-01, or later revisions."
-                    },
-                    "nonIban": {
-                        "type": "string",
-                        "description": "Non-IBAN account identifier.",
-                        "nullable": true
-                      }
+                    }
                 },
                 "additionalProperties": false
             },

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -483,7 +483,12 @@
                         "pattern": "[A-Z]{2,2}[0-9]{2,2}[a-zA-Z0-9]{1,30}",
                         "type": "string",
                         "description": "International Bank Account Number (IBAN) - identifier used internationally by financial institutions to uniquely identify the account of a customer. Further specifications of the format and content of the IBAN can be found in the standard ISO 13616 \"Banking and related financial services - International Bank Account Number (IBAN)\" version 1997-10-01, or later revisions."
-                    }
+                    },
+                    "nonIban": {
+                        "type": "string",
+                        "description": "Non-IBAN account identifier.",
+                        "nullable": true
+                      }
                 },
                 "additionalProperties": false
             },


### PR DESCRIPTION
Update to documentation only, no change to API functionality.
* Correct docs to include the nonIban field for Creditor Account
* Either the nonIban OR the Iban field must be provided as part of the CreditorAccount object