### PR TITLE
Homepage: PR log to show MergeDate instead of CreatedDate

### DIFF
--- a/gatsby/node/createPages.js
+++ b/gatsby/node/createPages.js
@@ -30,7 +30,7 @@ const ALL_PAGES_SCHEMA = `
           nodes {
             title
             state
-            createdAt
+            mergedAt
             url
           }
         }

--- a/src/containers/homepage/homepage.tsx
+++ b/src/containers/homepage/homepage.tsx
@@ -73,7 +73,7 @@ const Homepage: React.FC<any> = (props) => {
                         <Styles.TableTitleCell>
                           <a href={node.url} target="_blank" rel="noopener noreferrer">{node.title}</a>
                         </Styles.TableTitleCell>
-                        <Styles.TableDateCell>{dateFormatter(node.createdAt)}</Styles.TableDateCell>
+                        <Styles.TableDateCell>{dateFormatter(node.mergedAt)}</Styles.TableDateCell>
                       </tr>
                     ))}
                 </tbody>


### PR DESCRIPTION
Update to documentation only, no change to API functionality.
* GitHub PR log table on EU and UK homepages now shows `mergeDate` instead of `createdDate` of each pull request to reflect when each change was published.