### PR TITLE
GET EU Transactions provides more details for SCT Inst

### DIFF
--- a/data/endpoints/mccy-transactions-v1-eu.json
+++ b/data/endpoints/mccy-transactions-v1-eu.json
@@ -945,7 +945,7 @@
             "maxLength": 140,
             "minLength": 1,
             "type": "string",
-            "description": "A description of the transaction."
+            "description": "Unstructured remittance information about the transaction. If none was provided, then structured information is provided. Otherwise returns NOTPROVIDED."
           },
           "ultimateBeneficiary": {
             "$ref": "#/components/schemas/UltimateBeneficiary"

--- a/data/endpoints/mccy-transactions-v1-eu.json
+++ b/data/endpoints/mccy-transactions-v1-eu.json
@@ -945,7 +945,7 @@
             "maxLength": 140,
             "minLength": 1,
             "type": "string",
-            "description": "Unstructured remittance information about the transaction. If none was provided, then structured information is provided. Otherwise returns NOTPROVIDED."
+            "description": "Provides contextual information about the payment. For outbound SCT Inst  transactions, this will match the reference you supplied. For inbound SCT Inst, this provides unstructured remittance information; structured information if unstructured is not provided; otherwise `NOTPROVIDED`."
           },
           "ultimateBeneficiary": {
             "$ref": "#/components/schemas/UltimateBeneficiary"


### PR DESCRIPTION
Updated the field description `reference` to note heightened detail now being provided for SCT Inst transactions.
This affects the following endpoints:
* GET /mccy/v1/Accounts/{accountId}/transactions
* GET /mccy/v1/VirtualAccounts/{virtualAccountId}/transactions
* GET /mccy/v1/Transactions/{transactionId}