### PR TITLE
Docs fix: T2 ExchangeRate description

### DIFF
--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -385,7 +385,7 @@
                         "$ref": "#/components/schemas/CustomerPayments.CurrencyAmount"
                     },
                     "exchangeRate": {
-                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support EUR payments, this field should be populated with '1', or not be used.",
+                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support eur payments, this field should be populated with '1', or not used.",
                         "type": "number",
                         "format": "double"
                     },

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -385,7 +385,7 @@
                         "$ref": "#/components/schemas/CustomerPayments.CurrencyAmount"
                     },
                     "exchangeRate": {
-                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support eur payments, this field should be populated with '1', or not used.",
+                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support euro payments, this field should be populated with '1', or not used.",
                         "example": 1,
                         "type": "number",
                         "format": "double"

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -386,6 +386,7 @@
                     },
                     "exchangeRate": {
                         "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support eur payments, this field should be populated with '1', or not used.",
+                        "example": 1,
                         "type": "number",
                         "format": "double"
                     },

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -385,7 +385,7 @@
                         "$ref": "#/components/schemas/CustomerPayments.CurrencyAmount"
                     },
                     "exchangeRate": {
-                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to GBP.",
+                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to Euro. Note: As we only support Euro payments, this field should be populated with '1', or not be used.",
                         "type": "number",
                         "format": "double"
                     },

--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -385,7 +385,7 @@
                         "$ref": "#/components/schemas/CustomerPayments.CurrencyAmount"
                     },
                     "exchangeRate": {
-                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to Euro. Note: As we only support Euro payments, this field should be populated with '1', or not be used.",
+                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support EUR payments, this field should be populated with '1', or not be used.",
                         "type": "number",
                         "format": "double"
                     },


### PR DESCRIPTION
Update to documentation only, no change to API functionality.
* ExchangeRate description now reads EUR instead of GBP, added note about usage