### PR TITLE
Docs fix: T2 payment amend ExchangeRate note

### DIFF
--- a/data/endpoints/t2-v1.json
+++ b/data/endpoints/t2-v1.json
@@ -385,7 +385,7 @@
                         "$ref": "#/components/schemas/CustomerPayments.CurrencyAmount"
                     },
                     "exchangeRate": {
-                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: As we only support euro payments, this field should be populated with '1', or not used.",
+                        "description": "Exchange rate applied to convert the currency of the source amount or OriginalCurrency (prior to deduction of charges) to EUR. Note: If the original payment is in euro, this field should be populated with `1`, or not be used.",
                         "example": 1,
                         "type": "number",
                         "format": "double"


### PR DESCRIPTION
Update to documentation only, no change to API functionality.
* Amended note per PM request, noting OriginalCurrency is a factor