### PR TITLE
Docs fix: GBP Accounts correct virtual account OwnerName min/max length

### DIFF
--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7967,7 +7967,7 @@
         "type": "object",
         "properties": {
           "ownerName": {
-            "maxLength": 70,
+            "maxLength": 140,
             "minLength": 0,
             "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7968,7 +7968,7 @@
         "properties": {
           "ownerName": {
             "maxLength": 140,
-            "minLength": 0,
+            "minLength": 1,
             "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",
             "description": "The name used to identify the legal owner of the virtual account.",

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3579,7 +3579,7 @@
         "type": "object",
         "properties": {
           "ownerName": {
-            "maxLength": 70,
+            "maxLength": 140,
             "minLength": 1,
             "pattern": "^[^\\|_\\[\\]<>^`~\\\\$]*$",
             "type": "string",


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Correct min/max length for OwnerName fields in the below endpoints:
* PATCH /v1/accounts/{accountId}/virtual/{virtualAccountId}
* POST /v2/Accounts/{accountId}/Virtual