### PR TITLE
Docs fix: MCCY field descriptions and header parameters

### DIFF
--- a/data/endpoints/jpm-emulator-v1.json
+++ b/data/endpoints/jpm-emulator-v1.json
@@ -12,6 +12,34 @@
         ],
         "summary": "This endpoint is meant for the simulation environment only as it enables you to make an inbound payment into your account in our simulation environment.",
         "parameters": [
+
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Your API token, obtained from the ClearBank Portal.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "DigitalSignature",
+            "in": "header",
+            "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "A unique identifier for the request; valid for 24 hours, max length 83.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
           {
             "name": "accountUniqueId",
             "in": "path",

--- a/data/endpoints/mccy-initiate-payment-v1-dec21.json
+++ b/data/endpoints/mccy-initiate-payment-v1-dec21.json
@@ -723,7 +723,7 @@
       "AccountIdentifierKind": {
         "enum": [
           "AccountId",
-          "Iban"
+          "IBAN"
         ],
         "type": "string",
         "description": "The kind of account identifier provided. This can either be IBAN or AccountId. This field is case insensitive."

--- a/data/endpoints/mccy-initiate-payment-v1-dec21.json
+++ b/data/endpoints/mccy-initiate-payment-v1-dec21.json
@@ -12,6 +12,35 @@
           "Payments"
         ],
         "summary": "This endpoint is used to initiate payments.",
+        "parameters": [
+                    {
+                        "name": "Authorization",
+                        "in": "header",
+                        "description": "Your API token, obtained from the ClearBank Portal.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "DigitalSignature",
+                        "in": "header",
+                        "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "X-Request-Id",
+                        "in": "header",
+                        "description": "A unique identifier for the request; valid for 24 hours, max length 83.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -169,6 +198,33 @@
         "summary": "This endpoint is used to cancel an entire batch of payments with a matching batch ID. It must be sent at least one hour prior to the opening of the currency payment window in order to successfully cancel the payment.",
         "parameters": [
           {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Your API token, obtained from the ClearBank Portal.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "DigitalSignature",
+            "in": "header",
+            "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "A unique identifier for the request; valid for 24 hours, max length 83.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+          {
             "name": "batchId",
             "in": "path",
             "required": true,
@@ -278,6 +334,33 @@
         ],
         "summary": "This endpoint is used to cancel a single payment within a batch, with a matching batch ID and end-to-end ID. It must be sent at least one hour prior to the opening of the currency payment window in order to successfully cancel the payment.",
         "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "description": "Your API token, obtained from the ClearBank Portal.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "DigitalSignature",
+            "in": "header",
+            "description": "Signed hash of the body of the request. The hash is signed by your private key.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
+        {
+            "name": "X-Request-Id",
+            "in": "header",
+            "description": "A unique identifier for the request; valid for 24 hours, max length 83.",
+            "required": true,
+            "schema": {
+                "type": "string"
+            }
+        },
           {
             "name": "batchId",
             "in": "path",
@@ -643,7 +726,7 @@
           "Iban"
         ],
         "type": "string",
-        "description": "The kind of account identifier provided. This can either be IBAN or AccountId."
+        "description": "The kind of account identifier provided. This can either be IBAN or AccountId. This field is case insensitive."
       },
       "AccountIdentifier": {
         "required": [
@@ -1236,7 +1319,7 @@
           },
           "debtorAccountCurrency": {
             "type": "string",
-            "description": "Three-letter ISO currency code for the currency supported by the debtor account.",
+            "description": "Three-letter ISO currency code for the currency supported by the debtor account.  This field is case insensitive.",
             "minLength": 3,
             "maxLength": 3
           },
@@ -1280,7 +1363,7 @@
           },
           "currencyCode": {
             "type": "string",
-            "description": "Three-letter ISO currency code for the outbound payment.",
+            "description": "Three-letter ISO currency code for the outbound payment. This field is case insensitive.",
             "example": "EUR",
             "minLength": 3,
             "maxLength": 3


### PR DESCRIPTION
Update to documentation only; no change to API functionality.

- Added header parameters for MCCY payment endpoints
- Fixed `Iban` to `IBAN`
- Added descriptions to field that lack field sensitivity
  - CurrencyCode
  - DebtorAccountCurrency
  - AccountID > Kind