### PR TITLE
GBP Cross-Border update BIC field requirement

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -13,9 +13,9 @@ import ExternalLink from 'src/components/external-link';
 ## CHAPS
 
 <Callout colour="blue"><h2>Deprecation notice</h2><p>The following endpoints were deprecated on <strong>1 November 2024</strong>:<br />
-- <strong>POST payments/chaps/v4/customer-payments</strong><br />
-- <strong>POST payments/chaps/v4/institution-payments</strong><br />
-- <strong>POST payments/chaps/v4/return-payments</strong><br /></p>
+- <strong>POST /payments/chaps/v4/customer-payments</strong><br />
+- <strong>POST /payments/chaps/v4/institution-payments</strong><br />
+- <strong>POST /payments/chaps/v4/return-payments</strong><br /></p>
 
  <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 5 of these endpoints. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
 

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -555,7 +555,7 @@
                         "maxLength": 35,
                         "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
                         "type": "string",
-                        "description": "Recommend corporate and business clients provide your 8-character Company Registration Number (CRN) as shown on the Companies House register. Other identifiers such as FCA Firm Reference Numbers (FRNs) are also accepted."
+                        "description": "For corporate and business customers, we recommend setting this to their 8-character Company Registration Number (CRN) as shown on the Companies House register. Other identifiers such as FCA Firm Reference Numbers (FRNs) are also accepted."
                     }
                 },
                 "additionalProperties": false

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -555,7 +555,7 @@
                         "maxLength": 35,
                         "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ ]+$",
                         "type": "string",
-                        "description": "Corporates and Business can share their Companies House identifier with us here, this is normally eight characters long. Other identifiers such as the FCA Firm Reference Numbers could also be provided here."
+                        "description": "Recommend corporate and business clients provide your 8-character Company Registration Number (CRN) as shown on the Companies House register. Other identifiers such as FCA Firm Reference Numbers (FRNs) are also accepted."
                     }
                 },
                 "additionalProperties": false

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -566,6 +566,9 @@
         "additionalProperties": false
     },
     "CrossBorderCreditorAgentV6": {
+        "required": [
+            "bic"
+        ],
         "type": "object",
         "properties": {
             "bic": {
@@ -722,9 +725,6 @@
         "additionalProperties": false
     },
     "OrganisationIdentifierV5": {
-        "required": [
-            "bic"
-        ],
         "type": "object",
         "description": "Option to provide either OrganisationIdentifier or PrivateIdentifier, but not both.",
         "properties": {


### PR DESCRIPTION
One functionality change:
- Update Creditor.Bic and Debtor.Bic to be optional fields. 

Other updates to documentation only, no change to API functionality.
- Update CreditorAgent.Bic to show as mandatory for GBP Cross-Border payment endpoint
- Correct CHAPS deprecation notice
- Update CHAPS otherIdentification field description