### PR TITLE
Docs fix: Update GitHub build version

### DIFF
--- a/.github/workflows/build_site.yaml
+++ b/.github/workflows/build_site.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout 🛎️
         uses: actions/checkout@v2


### PR DESCRIPTION
Update runner from deprecated ubuntu `20.04` to `ubuntu-latest` per: https://github.com/actions/runner-images/issues/11101