### PR TITLE
GBP GET Transactions endpoints: add account holder name

### DIFF
--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3188,7 +3188,7 @@
           },
           "accountName": {
             "type": "string",
-            "description": "The account's name.",
+            "description": "The name of this account.",
             "example": "Current Account"
           },
           "accountHolderName": {
@@ -3198,7 +3198,7 @@
           },
           "sortCode": {
             "type": "string",
-            "description": "The account's sort code.",
+            "description": "The sort code for this account.",
             "example": "010203"
           },
           "accountNumber": {

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3198,7 +3198,7 @@
           },
           "sortCode": {
             "type": "string",
-            "description": "The sort code for this account.",
+            "description": "The account sort code.",
             "example": "010203"
           },
           "accountNumber": {

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3214,7 +3214,7 @@
             "$ref": "#/components/schemas/ClearBank.FI.API.Accounts.Versions.V2.Models.CounterpartAccountGenericIdentification"
           }
         },
-        "description": "The identifible information of an account."
+        "description": "The identifiable information of an account."
       },
       "ClearBank.FI.API.Accounts.Versions.V2.Models.CounterpartAccountGenericIdentification": {
         "required": [

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3188,7 +3188,7 @@
           },
           "accountName": {
             "type": "string",
-            "description": "The name of this account.",
+            "description": "The account name.",
             "example": "Current Account"
           },
           "accountHolderName": {

--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3188,12 +3188,17 @@
           },
           "accountName": {
             "type": "string",
-            "description": "The account name.",
+            "description": "The account's name.",
             "example": "Current Account"
+          },
+          "accountHolderName": {
+            "type": "string",
+            "description": "The account holder's name.",
+            "example": "Jenny Marr"
           },
           "sortCode": {
             "type": "string",
-            "description": "The accounts sort code.",
+            "description": "The account's sort code.",
             "example": "010203"
           },
           "accountNumber": {


### PR DESCRIPTION
Add accountHolderName to the response body of the following GET endpoints:
* /V2/Transactions
* /V2/Accounts/{AccountId}/Transactions/{TransactionId}
* /V2/Accounts/{AccountId}/Transactions
* /V2/Accounts/{AccountId}/Virtual/{VirtualAccountId}/Transactions/{TransactionId}
* /V2/Accounts/{AccountId}/Virtual/{VirtualAccountId}/Transactions

This field specifies the account holder's name.