### PR TITLE
Create a retail customer currentAddress 'array' to 'object'

### DIFF
--- a/data/endpoints/retail.json
+++ b/data/endpoints/retail.json
@@ -407,7 +407,7 @@
                         "$ref": "#/components/schemas/ClearBank.FI.API.Versions.V1.Models.CountryCodes"
                     },
                     "currentAddress": {
-                        "type": "array",
+                        "type": "object",
                         "items":
                             {
                                 "$ref": "#/components/schemas/ClearBank.FI.API.Versions.V1.Models.Binding.Customers.AddressRequest",


### PR DESCRIPTION
Update to documentation only; no change to API functionality

- CurrentAddress field changed from type `array` to `object`