### PR TITLE
SEPA CT Inbound Payment Recalled webhook: correct payload structure

### DIFF
--- a/webhooks/sepa-ct-inbound-payment-recalled-v1.mdx
+++ b/webhooks/sepa-ct-inbound-payment-recalled-v1.mdx
@@ -34,9 +34,9 @@ This webhook confirms an inbound SCT payment has had a recall request.
         "PaymentId": "31d42c5d-fa7f-4385-86e3-1ee9e2d60142",
         "CancellationReasonInformation": {
             "Reason": "CODE",
-            "AdditionalInformation": "AdditionalInformation",
-            "EndToEndIdentification": "5v8flwwosny59jsdg9t"
-        }
+            "AdditionalInformation": "AdditionalInformation"
+        },
+        "EndToEndIdentification": "5v8flwwosny59jsdg9t"
     },
     "Nonce": 185769097
 }


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Corrected structure to align with underlying behaviour:
* Moved EndToEndIdentification field out of CancellationReasonInformation object
* EndToEndIdentification is now an independent field in the payload