### PR TITLE
Update savings account closure response to show pending status

### DIFF
--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7711,7 +7711,7 @@
           },
           "closureStatus": {
             "type": "string",
-            "description": "State of the account closure request.",
+            "description": "State of the account closure request. Will be pending until the final interest payment is made.",
             "enum": [
               "None",
               "Pending",
@@ -7719,7 +7719,7 @@
               "Complete"
               
             ],
-            "example": "Complete"
+            "example": "Pending"
           }
         },
         "description": "Information representing the account closure request."


### PR DESCRIPTION
Change to documentation only. No change to API functionality.

Updated the information when closing a savings account to emphasise that closures will be `pending` until the final interest payment is made.