### PR TITLE
CHAPS and GBP Cross-Border old endpoint removal

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -15,9 +15,9 @@ import ExternalLink from 'src/components/external-link';
 ClearBank accounts support inbound and outbound CHAPS payments. As CHAPS is the UK’s high value payment scheme, there is no amount limit associated with inbound or outbound CHAPS payments.
 However, you can only send or return CHAPS payments between 08:00 – 17:00 Monday to Friday (excluding UK public holidays).
 
-- CHAPS payments can be sent using the [POST payments/chaps/v4/customer-payments](#send-a-chaps-payment) endpoint.
+- CHAPS payments can be sent using the [POST payments/chaps/v5/customer-payments](#send-a-chaps-payment) endpoint.
 - Settlement details are provided to you via the [Transaction Settled](#transaction-settled-webhook) webhook. 
-- If you need to return a CHAPS payment, you can do so using the [POST /payments/chaps/v4/return-payments](#return-a-chaps-payment) endpoint.
+- If you need to return a CHAPS payment, you can do so using the [POST /payments/chaps/v5/return-payments](#return-a-chaps-payment) endpoint.
 
 <Callout colour="blue">
   It is important to verify your firewall settings to ensure that they do not block <a href="#transaction-settled-webhook">Transaction Settled webhook</a> notifications, which can include a large payload due to the size of the Iso20022XmlDocument field.

--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -12,13 +12,6 @@ import ExternalLink from 'src/components/external-link';
 
 ## CHAPS
 
-<Callout colour="blue"><h2>Deprecation notice</h2><p>The following endpoints were deprecated on <strong>1 November 2024</strong>:<br />
-- <strong>POST /payments/chaps/v4/customer-payments</strong><br />
-- <strong>POST /payments/chaps/v4/institution-payments</strong><br />
-- <strong>POST /payments/chaps/v4/return-payments</strong><br /></p>
-
- <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 5 of these endpoints. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
-
 ClearBank accounts support inbound and outbound CHAPS payments. As CHAPS is the UK’s high value payment scheme, there is no amount limit associated with inbound or outbound CHAPS payments.
 However, you can only send or return CHAPS payments between 08:00 – 17:00 Monday to Friday (excluding UK public holidays).
 
@@ -128,18 +121,7 @@ The following table details common uses of Purpose Codes and Category Purpose Co
         'payment-message-validation-failed-webhook-v1',
         'transaction-rejected-v2'
         ]
-    },
-    {
-        path: "payments/chaps/v4/customer-payments",
-        version: "4.0.Chaps-payment",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        'payment-message-assessment-failed-webhook-v1',
-        'payment-message-validation-failed-webhook-v1',
-        'outbound-held-transaction-v1',
-        'transaction-rejected-v2'
-        ]
-    },
+    }
     ]}
 />
 
@@ -150,16 +132,6 @@ The following table details common uses of Purpose Codes and Category Purpose Co
         {
         path: "/payments/chaps/v5/return-payments",
         version: "5.0-ChapsReturn",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        'payment-message-assessment-failed-webhook-v1',
-        'payment-message-validation-failed-webhook-v1',
-        'transaction-rejected-v2'
-        ]
-    },
-    {
-        path: "/payments/chaps/v4/return-payments",
-        version: "4.0-ChapsReturn",
         webhooks: [
         'transaction-settled-webhook-v6',
         'payment-message-assessment-failed-webhook-v1',
@@ -177,17 +149,6 @@ The following table details common uses of Purpose Codes and Category Purpose Co
         {
         path: "/payments/chaps/v5/institution-payments",
         version: "5.0_BankToBank",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        'payment-message-assessment-failed-webhook-v1',
-        'payment-message-validation-failed-webhook-v1',
-        'outbound-held-transaction-v1',
-        'transaction-rejected-v2'
-        ]
-    },
-    {
-        path: "/payments/chaps/v4/institution-payments",
-        version: "4.0_BankToBank",
         webhooks: [
         'transaction-settled-webhook-v6',
         'payment-message-assessment-failed-webhook-v1',

--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -12,12 +12,6 @@ import ExternalLink from 'src/components/external-link';
 
 ## GBP Cross-Border
 
-<Callout colour="blue"><h2>Deprecation notice</h2><p>The following endpoints were deprecated on <strong>1 November 2024</strong>:<br />
-- <strong>POST /payments/cross-border-sterling/v1/payments</strong><br />
-- <strong>POST /payments/cross-border-sterling/v2/payments</strong><br /></p>
-
- <p>These endpoints will remain available for use until <strong>1 May 2025</strong>. We recommend switching to version 3 now. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
-
 Cross-border payments are financial transactions where the payer and the recipient are based in separate countries. Our GBP Cross-Border payment product enables you to send sterling payments to any sterling account, in any permissible overseas jurisdiction. 
 Payments are guaranteed to settle on the same-day, as long as the instruction is received before 5pm UK time on that working day.
 
@@ -131,26 +125,6 @@ The following table details common uses of Purpose Codes and Category Purpose Co
       {
       path: "/payments/cross-border-sterling/v3/payments",
         version: "3.0GBPCrossBorder",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        'payment-message-assessment-failed-webhook-v1',
-        'outbound-held-transaction-v1',
-        'transaction-rejected-v2'
-        ]
-    },
-      {
-      path: "/payments/cross-border-sterling/v2/payments",
-        version: "2.0GBPCrossBorder",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        'payment-message-assessment-failed-webhook-v1',
-        'outbound-held-transaction-v1',
-        'transaction-rejected-v2'
-        ]
-    },
-    {
-        path: "/payments/cross-border-sterling/v1/payments",
-        version: "1.0GBPCrossBorder",
         webhooks: [
         'transaction-settled-webhook-v6',
         'payment-message-assessment-failed-webhook-v1',


### PR DESCRIPTION
Remove details for endpoints which have now been switched off
CHAPS:
- POST /payments/chaps/v4/customer-payments
- POST /payments/chaps/v4/institution-payments
- POST /payments/chaps/v4/return-payments

GBP Cross-Border:
- POST /payments/cross-border-sterling/v1/payments
- POST /payments/cross-border-sterling/v2/payments