### PR TITLE
Docs fix only - CHAPS and GBP Cross-Border

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -25,34 +25,6 @@ However, you can only send or return CHAPS payments between 08:00 – 17:00 Mond
 
 The latest versions of the CHAPS endpoints support the new ISO20022 payment message formats. See [FIN to ISO20022 field mapping](#fin-to-iso-20022-field-mapping) for guidance on how the previous MT numbered field values map to the new ISO20022 XML tags.
 
-**CHAPS validation**
-
-| Element     | Type   | Validation                                                                      | Description                                                                                                                                                                                           |
-|-------------|--------|---------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `name`      | string | maxLength: 140<br /> minLength: 1 <br /> pattern: ``[0-9a-zA-Z/\-\?:\(\)\.,'\+ !#$%&\*=^_`\{\|\}~";<>@\[\\\]]+`` | **Also known as Account Holder Name** <br /> This the Creditor’s name.<br /> If max length exceeds 35 characters, this will be truncated before sending to scheme.                                   |
-| `reference` | string | maxLength: 35 <br /> minLength: 0 <br /> pattern: ``[0-9a-zA-Z/\-\?:\(\)\.,'\+ !#$%&\*=^_`\{\|\}~";<>@\[\\\]]+`` | **Also known as the Payment Reference** <br /> This is the Payment reference under remittance information.  |
-
-The character set defined by the pattern for the `name` and `reference` fields includes all SWIFT allowed characters. These are alphanumeric (uppercase and lowercase) and the special characters shown in this table:<br />
-
-|Special character|Description|Special character|Description|
-|---|----|---|---|
-|**\!**|Exclamation mark|**\|**|Pipe|
-|**\#**|Hash|**\}**|Right curly bracket|
-|**$**|Dollar sign|**\~**|Tilde|
-|**%**|Percent|**"**|Double straight quote|
-|**&**|Ampersand|**\(**|Left parenthesis|
-|**'**|Single straight quote|**\)**|Right parenthesis|
-|**\***|Asterisk|**,**|Comma|
-|**\+**|Plus sign|**:**|Colon|
-|**\-**|Hyphen|**;**|Semicolon|
-|**/**|Forward slash|**<**|Left angle bracket|
-|**=**|Equals sign|**\>**|Right angle bracket|
-|**?**|Question mark|**@**|At sign|
-|**^**|Caret|**\[**|Left square bracket|
-|**_**|Underscore|**\\**|Backslash|
-|**\`**|Backtick|**\]**|Right square bracket|
-|**\{**|Left curly bracket|||
-
 ### Version 5 mandatory fields
 In line with the Bank of England's ISO 20022 data enhancement requirements, you will be required to provide additional details on the debtor and creditor such as the Legal Entity Identifier (LEI), Purpose Code and Category Purpose Code.
 

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -584,9 +584,6 @@
         "additionalProperties": false
     },
     "CrossBorderCreditorIdentificationIbanDtoV4": {
-        "required": [
-            "iban"
-        ],
         "type": "object",
         "allOf": [{
             "$ref": "#/components/schemas/CrossBorderCreditorIdentificationDtoV4"


### PR DESCRIPTION
Update to documentation only, no change to API functionality.
- Old MT validation rules removed from CHAPS page as no longer relevant. Patterns are detailed in the endpoint fields.
- 'Required' tag removed from the CreditorAccount.Iban field of the GBP Cross-Border send payment endpoint. This is because a BBAN or other identification scheme can be used instead.