### PR TITLE
SCT Inst Reference field - Add min character length

### DIFF
--- a/data/endpoints/sepa-instant-v1.json
+++ b/data/endpoints/sepa-instant-v1.json
@@ -336,6 +336,7 @@
             "type": "string",
             "description": "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.",
             "nullable": true,
+            "minLength": 1,
             "maxLength": 35,
             "example": "INV-00002 2020-01-21"
           },


### PR DESCRIPTION
Add a minimum character length of 1 to the Reference field of the SCT Inst payment endpoint to prevent the field from being submitted with empty string values.