### PR TITLE
GBP Cross-Border documentation update

### DIFF
--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -23,11 +23,12 @@ Settlement details are provided to you via the [Transaction Settled](#transactio
 
 Things to note:
 
-- You can initiate a payment during the sterling availability period, 08:00 to 17:00 (UK time), on business days. Payments sent after this window closes will be rejected with a 400 Bad Request response.
-- If you use version 2, you do not need to provide the details of the intermediary agent. Instead, we'll use the details of the creditor to identify the correct intermediary agent on your behalf. We recommend using version 2 due to this benefit.
-- If you use version 1 of the endpoint, you'll need to include a GBP Direct Participant in the intermediary agent field.
+- You can initiate a payment during the sterling availability period, 08:00 to 17:00 (UK time), on business days. Payments sent before or after this window will be rejected with a 400 Bad Request response.
+- If you use **version 3** of the endpoint and choose to provide the optional Intermediary Agent field, the provided BIC must be a GB BIC belonging to a [CHAPS Direct Participant](https://www.bankofengland.co.uk/payment-and-settlement/chaps). Additionally, there must be a valid payment routing path from the Intermediary Agent to the Creditor Agent. If there is no valid routing path, or you provide a BIC that is not a GB BIC and a CHAPS Direct Participant, the payment will be rejected. If you're unsure, it's best to leave the Intermediary Agent field blank.
+  - Whether the Intermediary Agent field is present or not, we will always attempt to route the payment through the provided Creditor Agent BIC.
+- If you use **version 2**, you do not need to provide the details of the intermediary agent. Instead, we'll use the details of the creditor to identify the correct intermediary agent on your behalf.
+- If you use **version 1** of the endpoint, you'll need to include a GBP Direct Participant in the intermediary agent field.
 - You can recognise a Transaction Settled webhook that describes a GBP Cross-Border payment by checking the **TransactionSource** is set to **Cross Border GBP**.
-
 
 <Callout colour="blue">
   It is important to verify your firewall settings to ensure that they do not block <a href="#transaction-settled-webhook">Transaction Settled webhook</a> notifications, which can include a large payload due to the size of the Iso20022XmlDocument field.

--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -21,17 +21,20 @@ You can send GBP cross-border payments using the [POST /payments/cross-border-st
 
 Settlement details are provided to you via the [Transaction Settled](#transaction-settled-webhook) webhook. 
 
-Things to note:
+<Callout colour="blue">
+  It is important to verify your firewall settings to ensure that they do not block <a href="#transaction-settled-webhook">Transaction Settled webhook</a> notifications, which can include a large payload due to the size of the Iso20022XmlDocument field.
+</Callout>
+
+**Things to note:**
 
 - You can initiate a payment during the sterling availability period, 08:00 to 17:00 (UK time), on business days. Payments sent before or after this window will be rejected with a 400 Bad Request response.
-- If you use **version 3** of the endpoint and choose to provide the optional Intermediary Agent field, the provided BIC must be a GB BIC belonging to a [CHAPS Direct Participant](https://www.bankofengland.co.uk/payment-and-settlement/chaps). Additionally, there must be a valid payment routing path from the Intermediary Agent to the Creditor Agent. If there is no valid routing path, or you provide a BIC that is not a GB BIC and a CHAPS Direct Participant, the payment will be rejected. If you're unsure, it's best to leave the Intermediary Agent field blank.
-  - Whether the Intermediary Agent field is present or not, we will always attempt to route the payment through the provided Creditor Agent BIC.
+- If you use **version 3** of the endpoint and choose to provide the optional Intermediary Agent field, the provided BIC must be a GB BIC belonging to a [CHAPS Direct Participant](https://www.bankofengland.co.uk/payment-and-settlement/chaps#anchor_1672828379351). Additionally, there must be a valid payment routing path from the Intermediary Agent to the Creditor Agent. If there is no valid routing path, or you provide a BIC that is not a GB BIC and a CHAPS Direct Participant, the payment will be rejected. If you're unsure, it's best to leave the Intermediary Agent field blank.
 - If you use **version 2**, you do not need to provide the details of the intermediary agent. Instead, we'll use the details of the creditor to identify the correct intermediary agent on your behalf.
 - If you use **version 1** of the endpoint, you'll need to include a GBP Direct Participant in the intermediary agent field.
 - You can recognise a Transaction Settled webhook that describes a GBP Cross-Border payment by checking the **TransactionSource** is set to **Cross Border GBP**.
 
 <Callout colour="blue">
-  It is important to verify your firewall settings to ensure that they do not block <a href="#transaction-settled-webhook">Transaction Settled webhook</a> notifications, which can include a large payload due to the size of the Iso20022XmlDocument field.
+If you receive a Transaction Rejected webhook outside <a href="https://www.bankofengland.co.uk/payment-and-settlement/chaps">industry opening hours</a>, re-try the payment during the open window. If you do not receive a payment response webhook by the end of the day, you can expect a payment response webhook to be sent the following working day.
 </Callout>
 
 The GBP Cross-Border endpoint supports the new ISO20022 payment message formats, specifically pacs.008.

--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -29,43 +29,13 @@ Settlement details are provided to you via the [Transaction Settled](#transactio
 
 - You can initiate a payment during the sterling availability period, 08:00 to 17:00 (UK time), on business days. Payments sent before or after this window will be rejected with a 400 Bad Request response.
 - If you use **version 3** of the endpoint and choose to provide the optional Intermediary Agent field, the provided BIC must be a GB BIC belonging to a [CHAPS Direct Participant](https://www.bankofengland.co.uk/payment-and-settlement/chaps#anchor_1672828379351). Additionally, there must be a valid payment routing path from the Intermediary Agent to the Creditor Agent. If there is no valid routing path, or you provide a BIC that is not a GB BIC and a CHAPS Direct Participant, the payment will be rejected. If you're unsure, it's best to leave the Intermediary Agent field blank.
-- If you use **version 2**, you do not need to provide the details of the intermediary agent. Instead, we'll use the details of the creditor to identify the correct intermediary agent on your behalf.
-- If you use **version 1** of the endpoint, you'll need to include a GBP Direct Participant in the intermediary agent field.
 - You can recognise a Transaction Settled webhook that describes a GBP Cross-Border payment by checking the **TransactionSource** is set to **Cross Border GBP**.
 
 <Callout colour="blue">
-If you receive a Transaction Rejected webhook outside <a href="https://www.bankofengland.co.uk/payment-and-settlement/chaps">industry opening hours</a>, re-try the payment during the open window. If you do not receive a payment response webhook by the end of the day, you can expect a payment response webhook to be sent the following working day.
+If you receive a Transaction Rejected webhook outside of <a href="https://www.bankofengland.co.uk/payment-and-settlement/chaps">industry opening hours</a>, retry the payment during the next open window.
 </Callout>
 
-The GBP Cross-Border endpoint supports the new ISO20022 payment message formats, specifically pacs.008.
-
-### GBP Cross-Border validation
-
-| Element     | Type   | Validation | Description     |
-|-------------|--------|------------|-----------------|
-| `name`      | string | maxLength: 140<br /> minLength: 1 <br /> pattern: ``[0-9a-zA-Z/\-\?:\(\)\.,'\+ !#$%&\*=^_`\{\|\}~";<>@\[\\\]]+`` | **Also known as Account Holder Name** <br /> This the Creditor’s name.<br /> If max length exceeds 35 characters, this will be truncated before sending to scheme.   |
-| `reference` | string | maxLength: 35 <br /> minLength: 0 <br /> pattern: ``[0-9a-zA-Z/\-\?:\(\)\.,'\+ !#$%&\*=^_`\{\|\}~";<>@\[\\\]]+`` | **Also known as the Payment Reference** <br /> This is the Payment reference under remittance information.  |
-
-The character set defined by the pattern for the `name` and `reference` fields includes all SWIFT allowed characters. These are alphanumeric (uppercase and lowercase) and the special characters shown in this table:<br />
-
-|Special character|Description|Special character|Description|
-|---|----|---|---|
-|**\!**|Exclamation mark|**\|**|Pipe|
-|**\#**|Hash|**\}**|Right curly bracket|
-|**$**|Dollar sign|**\~**|Tilde|
-|**%**|Percent|**"**|Double straight quote|
-|**&**|Ampersand|**\(**|Left parenthesis|
-|**'**|Single straight quote|**\)**|Right parenthesis|
-|**\***|Asterisk|**,**|Comma|
-|**\+**|Plus sign|**:**|Colon|
-|**\-**|Hyphen|**;**|Semicolon|
-|**/**|Forward slash|**<**|Left angle bracket|
-|**=**|Equals sign|**\>**|Right angle bracket|
-|**?**|Question mark|**@**|At sign|
-|**^**|Caret|**\[**|Left square bracket|
-|**_**|Underscore|**\\**|Backslash|
-|**\`**|Backtick|**\]**|Right square bracket|
-|**\{**|Left curly bracket|||
+The GBP Cross-Border endpoint supports the new ISO 20022 payment message formats, specifically pacs.008.
 
 ### Version 3 mandatory fields
 In line with the Bank of England's ISO 20022 data enhancement requirements, you will be required to provide additional details on the debtor and creditor such as the Legal Entity Identifier (LEI), Purpose Code and Category Purpose Code.

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -514,8 +514,8 @@
                     "PLRF"
                 ],
                 "type": "string",
-                "minLength": "4",
-                "maxLength": "4",
+                "minLength": 4,
+                "maxLength": 4,
                 "example": "SALA",
                 "description": "Underlying reason for the payment transaction, as published in an external Purpose Code list."
             },
@@ -551,8 +551,8 @@
                     "WHLD"
                 ],
                 "type": "string",
-                "minLength": "4",
-                "maxLength": "4",
+                "minLength": 4,
+                "maxLength": 4,
                 "example": "SALA",
                 "description": "Broader nature of the payment, as published in an external Category Purpose Code list."
             },
@@ -560,6 +560,7 @@
                 "$ref": "#/components/schemas/StructuredRemittanceInformationDtoV4"
             },
             "intermediaryAgent1": {
+                "description": "Optional intermediary agent details for the payment. If provided, the BIC and name of the agent are required. If not provided, we will route the payment to the Creditor Agent BIC.",
                 "$ref": "#/components/schemas/IntermediaryAgentDetailsV4"
             }
         },
@@ -711,7 +712,7 @@
                 "minLength": 1,
                 "type": "string",
                 "example": "ABNANL2A",
-                "description": "Bank Identifier Code (BIC) of the entity. BIC11 recommended but BIC8 also supported."
+                "description": "Bank Identifier Code (BIC) of the entity. The BIC must be from a GB CHAPS Direct Participant. BIC11 recommended but BIC8 also supported."
             },
             "lei": {
                 "type": "string",


### PR DESCRIPTION
Update to documentation only; no change to API functionality.

- Removed information on validation for deprecated versions of the endpoint
- Added clarifying information on how to use v3 of the endpoint
- Added info on what to do if a payment is rejected out of hours