### PR TITLE
Update FX RFQ same-day cutoff times

### DIFF
--- a/content/uk/docs/multi-currency/fx-trade-rfq.mdx
+++ b/content/uk/docs/multi-currency/fx-trade-rfq.mdx
@@ -90,15 +90,15 @@ Refer to the below table detailing the cut-off times for all currently supported
 | Canadian Dollar  | CAD               | 07:00          | 13:00                          | 23:30                                     |
 | Swiss Franc      | CHF               | 07:00          | 09:30                          | 23:30                                     |
 | Czech Koruna     | CZK               | 07:00          | TBC                            | 23:30 (not yet enabled)                   |
-| Danish Krone     | DKK               | 07:00          | 09:30                          | 23:30                                     |
-| Euro             | EUR               | 07:00          | 13:00                          | 23:30                                     |
-| British Pounds   | GBP               | 07:00          | 13:00                          | 23:30                                     |
+| Danish Krone     | DKK               | 07:00          | 09:00                          | 23:30                                     |
+| Euro             | EUR               | 07:00          | 13:30                          | 23:30                                     |
+| British Pounds   | GBP               | 07:00          | 15:00                          | 23:30                                     |
 | Hungarian Forint | HUF               | 07:00          | TBC                            | 23:30 (not yet enabled)                   |
-| Norwegian Krone  | NOK               | 07:00          | 09:30                          | 23:30                                     |
+| Norwegian Krone  | NOK               | 07:00          | 09:00                          | 23:30                                     |
 | Polish Zloty     | PLN               | 07:00          | TBC                            | 23:30 (not yet enabled)                   |
 | Romanian Leu     | RON               | 07:00          | TBC                            | 23:30 (not yet enabled)                   |
 | Swedish Krona    | SEK               | 07:00          | 09:30                          | 23:30                                     |
-| United States Dollar | USD           | 07:00          | 13:00                          | 23:30                                     |
+| United States Dollar | USD           | 07:00          | 15:00                          | 23:30                                     |
 
  <Callout colour="blue">
 Cut-off times are under regular review and subject to change as we actively work to extend current cut-off times and extend our offering of currencies


### PR DESCRIPTION
Update to FX RFQ same-day cutoff times for EUR, GBP, USD, NOK, and DKK. These are now:
* EUR: 07:00 - 13:30
* GBP: 07:00 - 15:00
* USD: 07:00 - 15:00
* DKK: 07:00 - 09:00
* NOK: 07:00 - 09:00