### PR TITLE
Docs fix: GBP Account ClosureReason / StatusReason

### DIFF
--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7460,7 +7460,6 @@
           },
           "statusReason": {
             "enum": [
-              "NotProvided",
               "AccountHolderBankrupt",
               "AccountHolderDeceased",
               "AccountSwitched",

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7455,7 +7455,7 @@
               "Suspended"
             ],
             "type": "string",
-            "description": "Use this field to set the status of the account. If closing or suspending the account, you should also provide a StatusReason.",
+            "description": "Use this field to set the status of the account. If closing or suspending the account, you should provide a StatusReason. If you are not updating the account's status, either use 'NotProvided' or omit this field.",
             "example": "Enabled"
           },
           "statusReason": {
@@ -7480,7 +7480,7 @@
               "Other"
             ],
             "type": "string",
-            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply. Do not provide this if you are setting the status to 'Enabled'.",
+            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply. Do not provide this field if you are updating the status to 'Enabled'.",
             "example": "AccountHolderDeceased"
           },
           "ownerName": {
@@ -7659,7 +7659,6 @@
               "FinancialCrime",
               "FraudFirstParty",
               "FraudThirdParty",
-              "Other",
               "FraudConfirmed",
               "InternallyDormant",
               "KYCRequired",
@@ -7667,7 +7666,8 @@
               "PotentialSanctionedIndividual",
               "SanctionedIndividual",
               "SuspectMoneyLaundering",
-              "TransactionDispute"
+              "TransactionDispute",
+              "Other"
             ],
             "type": "string",
             "description": "The reason for closing the account. Use 'Other' if no other options apply.",

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7480,7 +7480,7 @@
               "Other"
             ],
             "type": "string",
-            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply.",
+            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply. Do not provide this if you are setting the status to 'enabled'.",
             "example": "AccountHolderDeceased"
           },
           "ownerName": {

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7481,7 +7481,7 @@
               "TransactionDispute"
             ],
             "type": "string",
-            "description": "Reason that the account is Closed or Suspended. Valid options include NotProvided, AccountHolderBankrupt, AccountHolderDeceased, AccountSwitched, CompanyNoLongerTrading, DissatisfiedCustomer, DuplicateSoleTraderAccount, FinancialCrime, FraudFirstParty, FraudThirdParty, FraudConfirmed, InternallyDormant, KYCRequired, LegallyDisputed, PotentialSanctionedIndividual, SanctionedIndividual, SuspectMoneyLaundering, TransactionDispute, Other.",
+            "description": "Reason that the account is Closed or Suspended. Valid options include AccountHolderBankrupt, AccountHolderDeceased, AccountSwitched, CompanyNoLongerTrading, DissatisfiedCustomer, DuplicateSoleTraderAccount, FinancialCrime, FraudFirstParty, FraudThirdParty, FraudConfirmed, InternallyDormant, KYCRequired, LegallyDisputed, PotentialSanctionedIndividual, SanctionedIndividual, SuspectMoneyLaundering, TransactionDispute, Other.",
             "example": "AccountHolderDeceased"
           },
           "ownerName": {

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7456,7 +7456,7 @@
             ],
             "type": "string",
             "description": "Use this field to set the status of the account. If closing or suspending the account, you should provide a StatusReason. If you are not updating the account's status, either use 'NotProvided' or omit this field.",
-            "example": "Enabled"
+            "example": "Closed"
           },
           "statusReason": {
             "enum": [

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7455,7 +7455,7 @@
               "Suspended"
             ],
             "type": "string",
-            "description": "Current status of the account. Valid options include Not Provided, Enabled, Closed, Suspended.",
+            "description": "Use this field to set the status of the account. If closing or suspending the account, you should also provide a StatusReason.",
             "example": "Enabled"
           },
           "statusReason": {

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7469,7 +7469,6 @@
               "FinancialCrime",
               "FraudFirstParty",
               "FraudThirdParty",
-              "Other",
               "FraudConfirmed",
               "InternallyDormant",
               "KYCRequired",
@@ -7477,10 +7476,11 @@
               "PotentialSanctionedIndividual",
               "SanctionedIndividual",
               "SuspectMoneyLaundering",
-              "TransactionDispute"
+              "TransactionDispute",
+              "Other"
             ],
             "type": "string",
-            "description": "Reason that the account is Closed or Suspended. Valid options include AccountHolderBankrupt, AccountHolderDeceased, AccountSwitched, CompanyNoLongerTrading, DissatisfiedCustomer, DuplicateSoleTraderAccount, FinancialCrime, FraudFirstParty, FraudThirdParty, FraudConfirmed, InternallyDormant, KYCRequired, LegallyDisputed, PotentialSanctionedIndividual, SanctionedIndividual, SuspectMoneyLaundering, TransactionDispute, Other.",
+            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply.",
             "example": "AccountHolderDeceased"
           },
           "ownerName": {
@@ -7670,7 +7670,7 @@
               "TransactionDispute"
             ],
             "type": "string",
-            "description": "Reason for the account closure request. Valid options include AccountHolderBankrupt, AccountHolderDeceased, AccountSwitched, CompanyNoLongerTrading, DissatisfiedCustomer, DuplicateSoleTraderAccount, FinancialCrime, FraudFirstParty, FraudThirdParty, FraudConfirmed, InternallyDormant, KYCRequired, LegallyDisputed, PotentialSanctionedIndividual, SanctionedIndividual, SuspectMoneyLaundering, TransactionDispute, Other.",
+            "description": "The reason for closing the account. Use 'Other' if no other options apply.",
             "example": "AccountHolderDeceased"
           }
         },

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7480,7 +7480,7 @@
               "Other"
             ],
             "type": "string",
-            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply. Do not provide this if you are setting the status to 'enabled'.",
+            "description": "If the account Status is Closed or Suspended, use this field to provide a reason. Use 'Other' if no other options apply. Do not provide this if you are setting the status to 'Enabled'.",
             "example": "AccountHolderDeceased"
           },
           "ownerName": {

--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -7651,7 +7651,6 @@
         "properties": {
           "closureReason": {
             "enum": [
-              "NotProvided",
               "AccountHolderBankrupt",
               "AccountHolderDeceased",
               "AccountSwitched",


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Updated descriptions for:
* **ClosureReason** field on **POST /v1/accounts/{accountId}/closure**
* **StatusReason** field on **PATCH /v1/accounts/{accountId}**

Removed `NotProvided` from both fields' enums as this is not a valid field value.
