### PR TITLE
Docs fix: amend GBP cross-border payment purpose details

### DIFF
--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -517,7 +517,7 @@
                 "minLength": 4,
                 "maxLength": 4,
                 "example": "SALA",
-                "description": "Underlying reason for the payment transaction, as published in an external Purpose Code list."
+                "description": "Underlying reason for the payment transaction, as set out in the Bank of England's ISO 20022 data enhancement requirements. Cannot be used to provide another country's payment reasons: use the optional creditorReferenceInformation field in the remittanceInformation object for this."
             },
             "categoryPurpose": {
                 "enum": [
@@ -554,7 +554,7 @@
                 "minLength": 4,
                 "maxLength": 4,
                 "example": "SALA",
-                "description": "Broader nature of the payment, as published in an external Category Purpose Code list."
+                "description": "A broader categorisation of the transaction's purpose, as set out in the Bank of England's ISO 20022 data enhancement requirements."
             },
             "remittanceInformation": {
                 "$ref": "#/components/schemas/StructuredRemittanceInformationDtoV4"
@@ -912,7 +912,7 @@
                 "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
                 "type": "string",
                 "example": "SALARY25112024",
-                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: you can use this field to provide an extra reference to aid in reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. May be used to provide another country's purpose code for the payment, such as the UAE or Canada."
             }
         },
         "additionalProperties": false,

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -912,7 +912,7 @@
                 "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
                 "type": "string",
                 "example": "SALARY25112024",
-                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: you can use this field to provide an extra reference to aid in reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. May be used to provide another country's purpose code for the payment, such as the UAE or Canada."
+                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: you can use this field to provide an extra reference to aid in reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. May be used to provide another country's purpose code for the payment, such as the UAE or India."
             }
         },
         "additionalProperties": false,

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -517,7 +517,7 @@
                 "minLength": 4,
                 "maxLength": 4,
                 "example": "SALA",
-                "description": "Underlying reason for the payment transaction, as set out in the Bank of England's ISO 20022 data enhancement requirements. Cannot be used to provide another country's payment reasons: use the optional creditorReferenceInformation field in the remittanceInformation object for this."
+                "description": "Underlying reason for the payment transaction, as set out in the Bank of England's ISO 20022 data enhancement requirements. When sending payments to countries requiring other purpose codes, you can provide them in the optional creditorReferenceInformation field in the remittanceInformation object."
             },
             "categoryPurpose": {
                 "enum": [

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -912,7 +912,7 @@
                 "pattern": "^[0-9a-zA-Z/\\-\\?:\\(\\)\\.,'\\+ !#$%&\\*=^_`\\{\\|\\}~\";<>@\\[\\\\\\]]+$",
                 "type": "string",
                 "example": "SALARY25112024",
-                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: you can use this field to provide an extra reference to aid in reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. May be used to provide another country's purpose code for the payment, such as the UAE or India."
+                "description": "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\n\nUsage: you can use this field to provide an extra reference to aid in reconciliation by the creditor upon receipt of the amount of money.\n\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification. May be used to provide another country's purpose code for the payment, such as the UAE or Bahrain."
             }
         },
         "additionalProperties": false,


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

Clarified how to provide a purpose code for countries that dont use ISO 20022 purpose codes.