### PR TITLE
FX Request for Quote maximum trade size increase

### DIFF
--- a/content/uk/docs/multi-currency/fx-trade-rfq.mdx
+++ b/content/uk/docs/multi-currency/fx-trade-rfq.mdx
@@ -127,7 +127,7 @@ Each FX currency pair has a defined maximum trade size per request. If you reque
 
 | Currency pair | Maximum trade size |
 | ------------- | ------------------ |
-| EUR/CAD       | 5,000,000 EUR      |
+| EUR/CAD       | 10,000,000 EUR     |
 | EUR/CHF       | 5,000,000 EUR      |
 | EUR/CZK       | 5,000,000 EUR      |
 | EUR/DKK       | 5,000,000 EUR      |
@@ -138,7 +138,7 @@ Each FX currency pair has a defined maximum trade size per request. If you reque
 | EUR/RON       | 5,000,000 EUR      |
 | EUR/SEK       | 5,000,000 EUR      |
 | EUR/USD       | 5,000,000 EUR      |
-| GBP/CAD       | 3,000,000 GBP      |
+| GBP/CAD       | 9,000,000 GBP      |
 | GBP/CHF       | 1,000,000 GBP      |
 | GBP/CZK       | 1,000,000 GBP      |
 | GBP/DKK       | 5,000,000 GBP      |
@@ -148,7 +148,7 @@ Each FX currency pair has a defined maximum trade size per request. If you reque
 | GBP/RON       | 1,000,000 GBP      |
 | GBP/SEK       | 5,000,000 GBP      |
 | GBP/USD       | 5,000,000 GBP      |
-| USD/CAD       | 5,000,000 USD      |
+| USD/CAD       | 12,000,000 USD     |
 | USD/CHF       | 5,000,000 USD      |
 | USD/CZK       | 5,000,000 USD      |
 | USD/DKK       | 5,000,000 USD      |


### PR DESCRIPTION
Increased the maximum trade size for 3 currency pairs in our FX Request for Quote (RFQ) service:
* EUR/CAD from 5,000,000 to 10,000,000 EUR
* GBP/CAD from 3,000,000 to 9,000,000 GBP
* USD/CAD from 5,000,000 to 12,000,000 USD