### PR TITLE
Docs fix: schemeName is not required in Transaction endpoints responses

### DIFF
--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3631,8 +3631,7 @@
       },
       "ClearBank.FI.API.Accounts.Versions.V2.Models.CounterpartAccountGenericIdentification": {
         "required": [
-          "identification",
-          "schemeName"
+          "identification"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
Documentation update only; no change to underlying endpoint behaviour.

Removed the `schemeName` field's 'required' property. This field is not always provided when ClearBank sends responses for the following endpoints:

- GET /v2/Transactions
- GET /v2/Accounts/{accountId}/Transactions
- GET /v2/Accounts/{accountId}/Transactions/{transactionId}
- GET /v2/Accounts/{accountId}/Virtual/{virtualAccountId}/Transactions
- GET /v2/Accounts/{accountId}/Virtual/{virtualAccountId}/Transactions/{transactionId}

