### PR TITLE
Docs Fix: GBP Transactions - Correct min/max and required of counterparty other identification

### DIFF
--- a/data/endpoints/sterling-v2.json
+++ b/data/endpoints/sterling-v2.json
@@ -3630,16 +3630,13 @@
         "description": "The identifiable information of an account."
       },
       "ClearBank.FI.API.Accounts.Versions.V2.Models.CounterpartAccountGenericIdentification": {
-        "required": [
-          "identification"
-        ],
         "type": "object",
         "properties": {
           "identification": {
-            "maxLength": 34,
-            "minLength": 1,
+            "maxLength": 255,
+            "minLength": 0,
             "type": "string",
-            "description": "Identification assigned by an institution.",
+            "description": "Identification assigned by an institution, or the fallback account descriptor when scheme-specific identifiers are unavailable.",
             "example": "GBR01020312345678"
           },
           "schemeName": {


### PR DESCRIPTION
Update to documentation only; no change to API functionality.

Corrected validation for `transaction(s).counterpartAccount.identification.other.identification` field:

* Minimum length corrected from `1` to `0`
* Maximum length corrected from `35` to `255`
* `identification` corrected from `required` to `optional`

This affects the following transactions endpoints:
* `GET /v2/Transactions`
* `GET /v2/Accounts/{accountId}/Transactions`
* `GET /v2/Accounts/{accountId}/Transactions/{transactionId}`
* `GET /v2/Accounts/{accountId}/Virtual/{virtualAccountId}/Transactions`
* `GET /v2/Accounts/{accountId}/Virtual/{virtualAccountId}/Transactions/{transactionId}`