### PR TITLE
Deprecate CHAPS and GBP Cross-Border endpoints

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -12,8 +12,17 @@ import ExternalLink from 'src/components/external-link';
 
 ## CHAPS
 
+<Callout colour="blue"><h2>Deprecation notice</h2>
+<p>The following endpoints were deprecated on <strong>13 May 2026</strong>:<br />
+- <strong>POST /payments/chaps/v5/customer-payments</strong><br />
+- <strong>POST /payments/chaps/v5/return-payments</strong><br />
+- <strong>POST /payments/chaps/v5/institution-payments</strong><br /></p>
+
+<p>These endpoints will remain available for use until <strong>13 November 2026</strong>. Version 6 of these endpoints will be available in Q3 2026. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
+
 ClearBank accounts support inbound and outbound CHAPS payments. As CHAPS is the UK’s high value payment scheme, there is no amount limit associated with inbound or outbound CHAPS payments.
-However, you can only send or return CHAPS payments between 08:00 – 17:00 Monday to Friday (excluding UK public holidays).
+
+You can send or return CHAPS payments between 08:00 – 17:00 Monday to Friday (excluding UK public holidays).
 
 - CHAPS payments can be sent using the [POST payments/chaps/v5/customer-payments](#send-a-chaps-payment) endpoint.
 - Settlement details are provided to you via the [Transaction Settled](#transaction-settled-webhook) webhook. 
@@ -188,7 +197,16 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 
 ## CHAPS simulation endpoints
 
-<Callout colour="blue"><h2>Deprecation notice</h2><p>The following endpoints were deprecated on <strong>8 December 2025</strong>:<br />
+<Callout colour="blue"><h2>Deprecation notice for sim</h2>
+<p>The following endpoints were deprecated on <strong>13 May 2026</strong>:<br />
+- <strong>POST /inbound-payment-simulation/chaps/v2/customer-payments</strong><br />
+- <strong>POST /inbound-payment-simulation/chaps/v2/return-payments</strong><br />
+- <strong>POST /v2/inbound-payment-simulation/return-payment-simplified</strong><br />
+- <strong>POST /inbound-payment-simulation/chaps/v2/institution-payments</strong><br /></p>
+
+<p>These endpoints will remain available for use until <strong>13 November 2026</strong>. Version 3 of these endpoints will be available in Q3 2026. Please reach out to your Client Director with any questions.</p>
+
+<p>The following endpoints were deprecated on <strong>8 December 2025</strong>:<br />
 - <strong>POST /inbound-payment-simulation/chaps/v1/customer-payments</strong><br />
 - <strong>POST /inbound-payment-simulation/chaps/v1/return-payments</strong><br />
 - <strong>POST /inbound-payment-simulation/chaps/v1/institution-payments</strong><br /></p>
@@ -197,7 +215,7 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 
 These endpoints can be used to simulate payments. You can also use them for automated testing.
 
-To support upcoming Bank of England changes effective 24 November 2025, we recommend using version 2 of the simulator endpoints for inbound CHAPS payments. Version 2 introduces support for both structured and hybrid address formats.
+To support upcoming Bank of England changes effective 13 November 2026, we will be issuing version 3 of the simulator endpoints for inbound CHAPS payments in late Q3. Version 3 removes support for unstructured address types, as well as other Bank of England mandated changes. This aligns with international SWIFT standards.
 
 <Callout colour="blue">
     Outbound CHAPS payments sent via ClearBank already use structured address formatting. No changes are required to your outbound integration.

--- a/content/uk/docs/gbp-payments/gbp-cross-border.mdx
+++ b/content/uk/docs/gbp-payments/gbp-cross-border.mdx
@@ -12,6 +12,12 @@ import ExternalLink from 'src/components/external-link';
 
 ## GBP Cross-Border
 
+<Callout colour="blue"><h2>Deprecation notice</h2>
+<p>The following endpoints were deprecated on <strong>13 May 2026</strong>:<br />
+- <strong>POST /payments/cross-border-sterling/v3/payments</strong><br /></p>
+
+<p>This endpoint will remain available for use until <strong>13 November 2026</strong>. Version 4 of this endpoint will be available in Q3 2026. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
+
 Cross-border payments are financial transactions where the payer and the recipient are based in separate countries. Our GBP Cross-Border payment product enables you to send sterling payments to any sterling account, in any permissible overseas jurisdiction. 
 Payments are guaranteed to settle on the same-day, as long as the instruction is received before 5pm UK time on that working day.
 

--- a/data/endpoints/chaps-bank-to-bank-v5.json
+++ b/data/endpoints/chaps-bank-to-bank-v5.json
@@ -10,7 +10,7 @@
                 "tags": [
                     "ExternalInstitutionPaymentsV5"
                 ],
-                "description": "Create an outbound bank-to-bank payment. This endpoint is used to send CHAPS Pacs.009 payments between financial institutions and is only available to authorised institutions.",
+                "description": "Create an outbound bank-to-bank payment. This endpoint is used to send CHAPS Pacs.009 payments between financial institutions and is only available to authorised institutions. Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
                 "operationId": "ExternalCreateInstitutionPayment-v5",
                 "parameters": [
                   {

--- a/data/endpoints/chaps-initiate-payment-v5.json
+++ b/data/endpoints/chaps-initiate-payment-v5.json
@@ -11,7 +11,7 @@
                 "tags": [
                     "ExternalCustomerPaymentsV5"
                 ],
-                "description": "This endpoint will send a CHAPS customer payment (pacs.008).",
+                "description": "This endpoint will send a CHAPS customer payment (pacs.008). Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
                 "operationId": "ExternalCreateCustomerPayment-v5",
                 "parameters": [
                   {

--- a/data/endpoints/chaps-return-v5.json
+++ b/data/endpoints/chaps-return-v5.json
@@ -10,7 +10,7 @@
                 "tags": [
                     "ExternalReturnPaymentsV5"
                 ],
-                "description": "Return a CHAPS payment. All CHAPS returns must be made by the next working day. The same operating hours apply for CHAPS returns as for regular CHAPS payments. Note that this endpoint only supports returning CHAPS payments made after the Bank of England's RTGS Renewal Programme went live (all payments made on or after 19 June 2023).",
+                "description": "Return a CHAPS payment. All CHAPS returns must be made by the next working day. The same operating hours apply for CHAPS returns as for regular CHAPS payments. Note that this endpoint only supports returning CHAPS payments made after the Bank of England's RTGS Renewal Programme went live (all payments made on or after 19 June 2023). Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
                 "operationId": "ExternalReturnPayment-v5",
                 "parameters": [
                   {

--- a/data/endpoints/chaps-rtgs-inbound-simulator-v2.json
+++ b/data/endpoints/chaps-rtgs-inbound-simulator-v2.json
@@ -10,7 +10,7 @@
         "tags": [
           "InboundSimulationV2"
         ],
-        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated inbound CHAPS payment, so that you will have a payment available to return. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook.",
+        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated inbound CHAPS payment, so that you will have a payment available to return. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook. Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
         "operationId": "CreateInboundCustomerPayment-v2",
         "parameters": [
           {
@@ -115,7 +115,7 @@
         "tags": [
           "InboundSimulationV2"
         ],
-        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated inbound bank-to-bank payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook.",
+        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated inbound bank-to-bank payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook. Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
         "operationId": "CreateInboundInstitutionPayment-v2",
         "parameters": [
           {
@@ -220,7 +220,7 @@
         "tags": [
           "InboundSimulationV2"
         ],
-        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated returned CHAPS payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook.",
+        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simulated returned CHAPS payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook. Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
         "operationId": "CreateInboundReturnPayment-v2",
         "parameters": [
           {
@@ -325,7 +325,7 @@
         "tags": [
           "InboundSimulationV2"
         ],
-        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simplified simulated returned CHAPS payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook.<br/><br/>If used repeatedly on the same outbound payment, this endpoint will continue to advise 200 responses for each request. You will not receive an error response. In the production environment, the expectation is that you will only receive a single pacs.004 return message for each outbound payment made.",
+        "description": "This endpoint exists to support your testing and development in our simulation environment. It does not apply to production. You can use it to send a simplified simulated returned CHAPS payment. Note that if this request is not successful because the payment details are incorrect, you will not receive a webhook.<br/><br/>If used repeatedly on the same outbound payment, this endpoint will continue to advise 200 responses for each request. You will not receive an error response. In the production environment, the expectation is that you will only receive a single pacs.004 return message for each outbound payment made. Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
         "operationId": "CreateInboundReturnPaymentSimplified-v2",
         "parameters": [
           {

--- a/data/endpoints/cross-border-v3.json
+++ b/data/endpoints/cross-border-v3.json
@@ -10,7 +10,7 @@
                 "tags": [
                     "ExternalCrossBorderCustomerPaymentsV6"
                 ],
-                "description": "This endpoint will send a cross-border customer payment in sterling (pacs.008).",
+                "description": "This endpoint will send a cross-border customer payment in sterling (pacs.008). Deprecation Notice: This endpoint was deprecated on 13 May 2026. The endpoint will remain available for use until 13 November 2026.",
                 "operationId": "ExternalCrossBorderCreateCustomerPayment-v6",
                 "parameters": [
                   {


### PR DESCRIPTION
Deprecation notice added for the following endpoints:

- POST /payments/chaps/v5/customer-payments
- POST /payments/chaps/v5/return-payments
- POST /payments/chaps/v5/institution-payments
- POST /payments/cross-border-sterling/v3/payments
- POST /inbound-payment-simulation/chaps/v2/customer-payments
- POST /inbound-payment-simulation/chaps/v2/return-payments
- POST /v2/inbound-payment-simulation/return-payment-simplified
- POST /inbound-payment-simulation/chaps/v2/institution-payments