### PR TITLE
KYC: split buildingNameNumber into 3 fields

### DIFF
--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -128,7 +128,7 @@
             "pattern": "^[a-zA-Z0-9\\-',.() ]+$",
             "type": "string",
             "example": "22(A)",
-            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or ",
+            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or one of buildingName and buildingNumber.",
             "nullable": true
           },
           "buildingName": {

--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -136,6 +136,7 @@
             "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
             "type": "string",
             "nullable": true,
+            "example": null,
             "description": "The building's name at this address. You must provide either this or a buildingNumber."
           },
           "buildingNumber": {
@@ -143,6 +144,7 @@
             "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
             "type": "string",
             "nullable": true,
+            "example": null,
             "description": "The building's number at this address. You must provide either this or a buildingName."
           },
           "subBuilding": {
@@ -150,6 +152,7 @@
             "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
             "type": "string",
             "nullable": true,
+            "example": null,
             "description": "Details of the sub-building at this address, such as an annexe, apartment, or flat."
           },
           "streetName": {

--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -128,7 +128,7 @@
             "pattern": "^[a-zA-Z0-9\\-',.() ]+$",
             "type": "string",
             "example": "22(A)",
-            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or one of buildingName and buildingNumber.",
+            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or buildingName and/or buildingNumber.",
             "nullable": true
           },
           "buildingName": {
@@ -137,7 +137,7 @@
             "type": "string",
             "nullable": true,
             "example": null,
-            "description": "The building's name at this address. You must provide either this or a buildingNumber."
+            "description": "The building's name at this address. You must provide either this and/or a buildingNumber."
           },
           "buildingNumber": {
             "maxLength": 255,
@@ -145,7 +145,7 @@
             "type": "string",
             "nullable": true,
             "example": null,
-            "description": "The building's number at this address. You must provide either this or a buildingName."
+            "description": "The building's number at this address. You must provide either this and/or a buildingName."
           },
           "subBuilding": {
             "maxLength": 255,

--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -104,6 +104,23 @@
           "postalCode",
           "streetName"
         ],
+        "anyOf": [
+          {
+            "required": [
+              "buildingNameNumber"
+            ]
+          },
+          {
+            "required": [
+              "buildingName"
+            ]
+          },
+          {
+            "required": [
+              "buildingNumber"
+            ]
+          }
+        ],
         "type": "object",
         "properties": {
           "buildingNameNumber": {

--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -100,7 +100,6 @@
     "schemas": {
       "Address": {
         "required": [
-          "buildingNameNumber",
           "countryCode",
           "postalCode",
           "streetName"
@@ -109,11 +108,32 @@
         "properties": {
           "buildingNameNumber": {
             "maxLength": 40,
-            "minLength": 1,
             "pattern": "^[a-zA-Z0-9\\-',.() ]+$",
             "type": "string",
             "example": "22(A)",
-            "description": "The name or number of the customer's home at their address."
+            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or ",
+            "nullable": true
+          },
+          "buildingName": {
+            "maxLength": 255,
+            "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
+            "type": "string",
+            "nullable": true,
+            "description": "The building's name at this address. You must provide either this or a buildingNumber."
+          },
+          "buildingNumber": {
+            "maxLength": 255,
+            "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
+            "type": "string",
+            "nullable": true,
+            "description": "The building's number at this address. You must provide either this or a buildingName."
+          },
+          "subBuilding": {
+            "maxLength": 255,
+            "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
+            "type": "string",
+            "nullable": true,
+            "description": "Details of the sub-building at this address, such as an annexe, apartment, or flat."
           },
           "streetName": {
             "maxLength": 50,

--- a/data/endpoints/know-your-customer-v1.json
+++ b/data/endpoints/know-your-customer-v1.json
@@ -107,11 +107,6 @@
         "anyOf": [
           {
             "required": [
-              "buildingNameNumber"
-            ]
-          },
-          {
-            "required": [
               "buildingName"
             ]
           },
@@ -123,14 +118,6 @@
         ],
         "type": "object",
         "properties": {
-          "buildingNameNumber": {
-            "maxLength": 40,
-            "pattern": "^[a-zA-Z0-9\\-',.() ]+$",
-            "type": "string",
-            "example": "22(A)",
-            "description": "The name or number of the customer's home at their address. Provide either buildingNameNumber, or buildingName and/or buildingNumber.",
-            "nullable": true
-          },
           "buildingName": {
             "maxLength": 255,
             "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
@@ -144,7 +131,7 @@
             "pattern": "^(?=.*[a-zA-Z0-9])[a-zA-Z0-9 ,.'()\\-]+$",
             "type": "string",
             "nullable": true,
-            "example": null,
+            "example": "270",
             "description": "The building's number at this address. You must provide either this and/or a buildingName."
           },
           "subBuilding": {


### PR DESCRIPTION
The field `buildingNameNumber` has been broken into 3 different fields:

* `buildingNumber`
* `buildingName`
* `subBuilding`