### PR TITLE
Fix: Legal entity field descriptions

### DIFF
--- a/data/endpoints/customers_v2_legal_entity.json
+++ b/data/endpoints/customers_v2_legal_entity.json
@@ -2231,7 +2231,7 @@
           "Yes_International"
         ],
         "type": "string",
-        "description": "Indicates if the customer is a Politically Exposed Person."
+        "description": "Indicates if the customer has a Politically Exposed Person link, association, or connection in its controlling structure."
       },
       "PreviousAddressRequest": {
         "required": [
@@ -2348,7 +2348,7 @@
           "Yes_International"
         ],
         "type": "string",
-        "description": "Indicates if the customer is a relative or close associate."
+        "description": "Indicates if the customer has a relative or close associate link, association, or connection in its controlling structure."
       },
       "ReasonForNoTaxId": {
         "enum": [

--- a/data/endpoints/customers_v2_legal_entity.json
+++ b/data/endpoints/customers_v2_legal_entity.json
@@ -1755,7 +1755,7 @@
           }
         },
         "additionalProperties": false,
-        "description": "The customer's address history for multiple current addresses"
+        "description": "The customer's address history for multiple current addresses."
       },
       "CreateRelatedPartyRequest": {
         "required": [


### PR DESCRIPTION
Update to documentation only; no change to API functionality.

Updated descriptions for `Pep` and `Rca` fields in POST /customers/v2/legal-entities.