### PR TITLE
Docs fix: Payment Account example value

### DIFF
--- a/data/endpoints/sterling-v1.json
+++ b/data/endpoints/sterling-v1.json
@@ -8695,7 +8695,7 @@
               "$ref": "#/components/schemas/ClearBank.FI.API.Accounts.Versions.V1.Models.Binding.Accounts.Customer"
             },
             "description": "An array of customers that will hold the account. Use an array of size 1 to create an account for just one customer.",
-            "example": ["123278ab-05c5-5d8a-bba5-db43a578ee9f", "cf938d5b-c350-50a4-a4d1-cecb792ecdb6"]
+            "example": [{"customerId": "123278ab-05c5-5d8a-bba5-db43a578ee9f"}, {"customerId": "cf938d5b-c350-50a4-a4d1-cecb792ecdb6"}]
           }
         },
         "description": "Information that is used to create a Payment Account."


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

* Corrected example values for payment account request.