### PR TITLE
Docs Fix: Sole Trader identityDocuments

### DIFF
--- a/data/endpoints/customers_v2_sole_trader.json
+++ b/data/endpoints/customers_v2_sole_trader.json
@@ -2008,8 +2008,7 @@
           "businessDetails",
           "kycAml",
           "personalDetails",
-          "taxDetails",
-          "identityDocuments"
+          "taxDetails"
         ],
         "type": "object",
         "properties": {

--- a/data/endpoints/customers_v2_sole_trader.json
+++ b/data/endpoints/customers_v2_sole_trader.json
@@ -2023,7 +2023,7 @@
             "items": {
               "$ref": "#/components/schemas/CreateCustomerIdentityDocumentRequest"
             },
-            "description": "The customer's identity documents. You must provide either a nationalIdentificationNumber or at least one identity document.",
+            "description": "The customer's identity documents.",
             "nullable": true
           },
           "businessDetails": {


### PR DESCRIPTION
Update to documentation only, no change to endpoint functionality.

Corrected Create a Sole Trader (**POST /customers/v2/sole-traders**) such that the `identityDocuments` object is optional, aligning with the underlying endpoint. Updated description to reflect this.