### PR TITLE
Remove CHAPS v1 simulation endpoints 

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -206,12 +206,7 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 
 <p>These endpoints will remain available for use until <strong>13 November 2026</strong>. Version 3 of these endpoints will be available in Q3 2026. Please reach out to your Client Director with any questions.</p>
 
-<p>The following endpoints were deprecated on <strong>8 December 2025</strong>:<br />
-- <strong>POST /inbound-payment-simulation/chaps/v1/customer-payments</strong><br />
-- <strong>POST /inbound-payment-simulation/chaps/v1/return-payments</strong><br />
-- <strong>POST /inbound-payment-simulation/chaps/v1/institution-payments</strong><br /></p>
-
-<p>These endpoints will remain available for use until <strong>8 June 2026</strong>. We recommend switching to version 2 of these endpoints. Please reach out to your Client Director with any questions.</p> <p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
+<p>You can refer to our <a href="../api/versioning">versioning policy</a> and <a href="../api/support-life-cycle">support lifecycle information</a>.</p></Callout>
 
 These endpoints can be used to simulate payments. You can also use them for automated testing.
 
@@ -236,13 +231,6 @@ The ClearBank Payment Simulator should no longer be used for CHAPS payments.
     {
         path: "/inbound-payment-simulation/chaps/v2/customer-payments",
         version: "2.0-ChapsSim",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        ]
-    },
-    {
-        path: "/inbound-payment-simulation/chaps/v1/customer-payments",
-        version: "1.0-ChapsSim",
         webhooks: [
         'transaction-settled-webhook-v6',
         ]
@@ -363,13 +351,6 @@ The ClearBank Payment Simulator should no longer be used for CHAPS payments.
         webhooks: [
         'transaction-settled-webhook-v6',
         ]
-    },
-    {
-        path: "/inbound-payment-simulation/chaps/v1/return-payments",
-        version: "1.0-ChapsSim",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        ]
     }
     ]}
 />
@@ -395,13 +376,6 @@ The ClearBank Payment Simulator should no longer be used for CHAPS payments.
         {
         path: "/inbound-payment-simulation/chaps/v2/institution-payments",
         version: "2.0-ChapsSim",
-        webhooks: [
-        'transaction-settled-webhook-v6',
-        ]
-    },
-    {
-        path: "/inbound-payment-simulation/chaps/v1/institution-payments",
-        version: "1.0-ChapsSim",
         webhooks: [
         'transaction-settled-webhook-v6',
         ]


### PR DESCRIPTION
The following CHAPS simulation endpoints have been deprecated and removed:
- POST /inbound-payment-simulation/chaps/v1/customer-payments
- POST /inbound-payment-simulation/chaps/v1/return-payments
- POST /inbound-payment-simulation/chaps/v1/institution-payments