### PR TITLE
Sepa Direct Debit: Payment Refusal Completed webhook

### DIFF
--- a/content/eu/direct/sepa-direct-debit.mdx
+++ b/content/eu/direct/sepa-direct-debit.mdx
@@ -151,7 +151,7 @@ A refusal is a **pre-settlement R-flow** where a SEPA Direct Debit collection is
 
 Refusals can arise either when the debtor account cannot be debited - such as due to insufficient funds or account restrictions - or when the instruction fails scheme validation checks.
 
-Refusals can be initiated until up to 10:45 Netherlands time on the settlement day. After this time, a refusal can no longer be initiated and the request will be rejected and not processed.
+Refusals can be initiated until up to 10:45 Netherlands time on the collection day. After this time, a refusal can no longer be initiated and the request will be rejected and not processed.
 
 <Callout colour="blue">
   Our cut-off time follows daylight savings, so we recommend aligning to Central European Standard Time or Western Europe Standard Time on Windows, and Europe/Amsterdam if on Linux.

--- a/content/eu/direct/sepa-direct-debit.mdx
+++ b/content/eu/direct/sepa-direct-debit.mdx
@@ -173,12 +173,14 @@ Refusals can be initiated until up to 10:45 Netherlands time on the collection d
 
 #### Simulate a SEPA DD Refusal
 
+Before simulating a refusal, an inbound SDD must first be created via the [POST /payments/sepa-dd/v1/emulator/inbound-direct-debits](#simulate-an-inbound-sdd-payment-request) endpoint with a future-dated `requestedCollectionDate` (see [Simulate an inbound SDD payment request](#simulate-an-inbound-sdd-payment-request)).
+
 To simulate a SEPA DD refusal, call the [POST /payments/sepa-dd/v1/r-message-instructions](#simulate-an-r-flow-for-a-sepa-direct-debit-payment) endpoint.
 
 Fields must be populated with:
 
 - An appropriate refusal reason code.
-- The original payment ID, as set out in [POST /payments/sepa-dd/v1/emulator/inbound-direct-debits](#simulate-an-inbound-sdd-payment-request).
+- The original payment ID from the inbound SDD request.
 
 ### Return
 

--- a/content/eu/direct/sepa-direct-debit.mdx
+++ b/content/eu/direct/sepa-direct-debit.mdx
@@ -147,9 +147,27 @@ SEPA Direct Debit has three 'R-flows': Refuse, Return, and Refund. Each R-flow r
 
 ### Refuse
 
-<Callout colour="blue">
-  Further details to be confirmed.
-</Callout>
+A refusal is a **pre-settlement R-flow** where a SEPA Direct Debit collection is rejected before settlement.
+
+Refusals can occur when the debtor account cannot be debited or the instruction fails scheme validation checks.
+
+#### Refusal reason code table
+
+| Reason Code | Description                          |
+| ----------- | ------------------------------------ |
+| `AC06`      | BlockedAccount                       |
+| `AM04`      | InsufficientFunds                    |
+| `BE05`      | UnrecognisedInitiatingParty          |
+| `MD01`      | NoMandate                            |
+| `MD02`      | MissingMandatoryInformationInMandate |
+| `MD07`      | EndCustomerDeceased                  |
+| `MS02`      | NotSpecifiedReasonCustomerGenerated  |
+| `MS03`      | NotSpecifiedReasonAgentGenerated     |
+| `RR04`      | RegulatoryReason                     |
+
+#### Simulate a SEPA DD Refusal
+
+To simulate a SEPA DD refusal, call the [POST /payments/sepa-dd/v1/r-message-instructions](#simulate-an-r-flow-for-a-sepa-direct-debit-payment) endpoint. Fields must be populated with an appropriate refusal reason code and the original payment ID set out in [POST /payments/sepa-dd/v1/emulator/inbound-direct-debits](#simulate-an-inbound-sdd-payment-request).
 
 ### Return
 
@@ -209,6 +227,7 @@ These timeframes are only applicable in our EU production environment: you can s
       path: "/payments/sepa-dd/v1/r-message-instructions",
       version: "1.0.SEPA-R-FLOW",
       webhooks: [
+        'sepa-dd-debit-refusal-completed-v1',
         'sepa-dd-debit-payment-return-completed-v1'
       ]
     }
@@ -269,3 +288,5 @@ ClearBank uses webhooks to notify you of inbound SEPA Core Direct Debit activity
 <WebhookPlaceholder render='sepa-dd-debit-payment-return-completed-v1' />
 
 <WebhookPlaceholder render='sepa-dd-debit-payment-refund-completed-v1' />
+
+<WebhookPlaceholder render='sepa-dd-debit-refusal-completed-v1' />

--- a/content/eu/direct/sepa-direct-debit.mdx
+++ b/content/eu/direct/sepa-direct-debit.mdx
@@ -147,9 +147,15 @@ SEPA Direct Debit has three 'R-flows': Refuse, Return, and Refund. Each R-flow r
 
 ### Refuse
 
-A refusal is a **pre-settlement R-flow** where a SEPA Direct Debit collection is rejected before settlement.
+A refusal is a **pre-settlement R-flow** where a SEPA Direct Debit collection is rejected before settlement takes place. This means the debtor's account will not be debited and the payment will not proceed.
 
-Refusals can occur when the debtor account cannot be debited or the instruction fails scheme validation checks.
+Refusals can arise either when the debtor account cannot be debited - such as due to insufficient funds or account restrictions - or when the instruction fails scheme validation checks.
+
+Refusals can be initiated until up to 10:45 Netherlands time on the settlement day. After this time, a refusal can no longer be initiated and the request will be rejected and not processed.
+
+<Callout colour="blue">
+  Our cut-off time follows daylight savings, so we recommend aligning to Central European Standard Time or Western Europe Standard Time on Windows, and Europe/Amsterdam if on Linux.
+</Callout>
 
 #### Refusal reason code table
 
@@ -167,7 +173,12 @@ Refusals can occur when the debtor account cannot be debited or the instruction 
 
 #### Simulate a SEPA DD Refusal
 
-To simulate a SEPA DD refusal, call the [POST /payments/sepa-dd/v1/r-message-instructions](#simulate-an-r-flow-for-a-sepa-direct-debit-payment) endpoint. Fields must be populated with an appropriate refusal reason code and the original payment ID set out in [POST /payments/sepa-dd/v1/emulator/inbound-direct-debits](#simulate-an-inbound-sdd-payment-request).
+To simulate a SEPA DD refusal, call the [POST /payments/sepa-dd/v1/r-message-instructions](#simulate-an-r-flow-for-a-sepa-direct-debit-payment) endpoint.
+
+Fields must be populated with:
+
+- An appropriate refusal reason code.
+- The original payment ID, as set out in [POST /payments/sepa-dd/v1/emulator/inbound-direct-debits](#simulate-an-inbound-sdd-payment-request).
 
 ### Return
 

--- a/webhooks/sepa-dd-debit-payment-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-payment-completed-v1.mdx
@@ -6,8 +6,6 @@ webhook: true
 
 Sent when a SEPA Direct Debit payment is collected from an account.
 
-You will receive this webhook once ClearBank has successfully completed processing a refusal for a Direct Debit collection. After you receive this webhook, the collection will not settle, and no debit will be applied to the debtor's account.
-
 **Note:** You can correlate settled payments with the original collection using the `paymentId` and `transactionId` as these correspond to the same fields in the Payment Collection Pending webhook.
 
 #### Request body

--- a/webhooks/sepa-dd-debit-payment-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-payment-completed-v1.mdx
@@ -4,7 +4,9 @@ version: 1
 webhook: true
 ---
 
-Sent when a SEPA Direct Debit payment is collected from an account. Follows the SEPA DD Debit Payment Collection Pending webhook.
+Sent when a SEPA Direct Debit payment is collected from an account.
+
+You will receive this webhook once ClearBank has successfully completed processing a refusal for a Direct Debit collection. After you receive this webhook, the collection will not settle, and no debit will be applied to the debtor's account.
 
 **Note:** You can correlate settled payments with the original collection using the `paymentId` and `transactionId` as these correspond to the same fields in the Payment Collection Pending webhook.
 

--- a/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
@@ -19,10 +19,10 @@ Notifies when a SEPA Direct Debit payment refusal has completed.
 
 ##### Payload Fields
 
-| Field           | Type   | Format | Required | Min/Max length | Pattern                                                                         | Description                                  |
-| --------------- | ------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
-| `PaymentId`     | string | guid   | Yes      | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank transaction identifier.     |
-| `TransactionId` | string | guid   | No       | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification assigned by ClearBank. |
+| Field           | Type   | Format | Required | Min/Max length | Pattern                                                                         | Description                                                                                     |
+| --------------- | ------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `PaymentId`     | string | guid   | Yes      | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank identifier for the transaction we will apply on to the advised Debtor Account. |
+| `TransactionId` | string | guid   | No       | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification, assigned by ClearBank, to unambiguously identify the transaction.        |
 
 #### Example SEPA DD Debit Payment Refusal Completed webhook request body
 

--- a/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
@@ -6,7 +6,7 @@ webhook: true
 
 Notifies when a SEPA Direct Debit payment refusal has completed.
 
-## Request body
+#### Request body
 
 ```json
 {
@@ -17,14 +17,14 @@ Notifies when a SEPA Direct Debit payment refusal has completed.
 }
 ```
 
-## Payload Fields
+##### Payload Fields
 
 | Field           | Type   | Format | Required | Min length | Max length | Pattern                                                                          | Description                                |
 | --------------- | ------ | ------ | -------- | ---------- | ---------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
 | `PaymentId`     | string | guid   | Yes      | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank transaction identifier.   |
 | `TransactionId` | string | guid   | No       | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification assigned by ClearBank. |
 
-## Example SEPA DD Debit Payment Refusal Completed webhook request body
+#### Example SEPA DD Debit Payment Refusal Completed webhook request body
 
 ```json
 {
@@ -38,7 +38,7 @@ Notifies when a SEPA Direct Debit payment refusal has completed.
 }
 ```
 
-## Example webhook response
+#### Example webhook response
 
 ```json
 {

--- a/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
@@ -19,10 +19,10 @@ Notifies when a SEPA Direct Debit payment refusal has completed.
 
 ##### Payload Fields
 
-| Field           | Type   | Format | Required | Min length | Max length | Pattern                                                                          | Description                                |
-| --------------- | ------ | ------ | -------- | ---------- | ---------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
-| `PaymentId`     | string | guid   | Yes      | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank transaction identifier.   |
-| `TransactionId` | string | guid   | No       | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification assigned by ClearBank. |
+| Field           | Type   | Format | Required | Min/Max length | Pattern                                                                         | Description                                  |
+| --------------- | ------ | ------ | -------- | -------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
+| `PaymentId`     | string | guid   | Yes      | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank transaction identifier.     |
+| `TransactionId` | string | guid   | No       | 36/36          | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification assigned by ClearBank. |
 
 #### Example SEPA DD Debit Payment Refusal Completed webhook request body
 

--- a/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
@@ -1,0 +1,47 @@
+---
+title: "SEPA DD Debit Payment Refusal Completed webhook"
+version: 1
+webhook: true
+---
+
+Notifies when a SEPA Direct Debit payment refusal has completed.
+
+## Request body
+
+```json
+{
+  "Type": "Sepa.DD.DebitPayment.RefusalCompleted",
+  "Version": 1,
+  "Payload": {...},
+  "Nonce":
+}
+```
+
+## Payload Fields
+
+| Field           | Type   | Format | Required | Min length | Max length | Pattern                                                                          | Description                                |
+| --------------- | ------ | ------ | -------- | ---------- | ---------- | -------------------------------------------------------------------------------- | ------------------------------------------ |
+| `PaymentId`     | string | guid   | Yes      | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique ClearBank transaction identifier.   |
+| `TransactionId` | string | guid   | No       | 36         | 36         | `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$` | Unique identification assigned by ClearBank. |
+
+## Example SEPA DD Debit Payment Refusal Completed webhook request body
+
+```json
+{
+  "Type": "Sepa.DD.DebitPayment.RefusalCompleted",
+  "Version": 1,
+  "Payload": {
+    "PaymentId": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "TransactionId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  },
+  "Nonce": 781245093
+}
+```
+
+## Example webhook response
+
+```json
+{
+  "Nonce": 781245093
+}
+```

--- a/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
+++ b/webhooks/sepa-dd-debit-refusal-completed-v1.mdx
@@ -6,6 +6,8 @@ webhook: true
 
 Notifies when a SEPA Direct Debit payment refusal has completed.
 
+You will receive this webhook once ClearBank has successfully completed processing a refusal for an SDD collection. After you receive this webhook, the collection will not settle, and no debit will be applied to the debtor's account.
+
 #### Request body
 
 ```json


### PR DESCRIPTION
Add Refusal Completed webhook for the Sepa Direct Debit R-flow.

Amendments:

* `Sepa.DD.DebitPayment.RefusalCompleted` - SEPA DD Debit Payment Refusal Completed.
* Steps to simulate this payment flow have been documented.