### PR TITLE
Fix: Updates to v2 retail and legal entity docs

### DIFF
--- a/data/endpoints/customers_v2_legal_entity.json
+++ b/data/endpoints/customers_v2_legal_entity.json
@@ -1535,7 +1535,7 @@
           "VeryHighRisk"
         ],
         "type": "string",
-        "description": "CRA Rating"
+        "description": "The customer's CRA rating. Determined by the outcomes of your due diligence checks."
       },
       "CreateKycAmlRequest": {
         "required": [

--- a/data/endpoints/customers_v2_retail.json
+++ b/data/endpoints/customers_v2_retail.json
@@ -1989,7 +1989,7 @@
               "$ref": "#/components/schemas/SpecialStatusValue"
             },
             "description": "The customer's special statuses, if any. Possible values include: 'Vulnerability_Health_VisualImpairmentBraille', 'Vulnerability_Health_VisualImpairmentLargeText', 'Vulnerability_Health_AudioImpairment', 'Vulnerability_Health_Other', 'Vulnerability_LifeEvents', 'Vulnerability_Resilience', and 'Vulnerability_Capability'",
-            "example": "Vulnerability_LifeEvents",
+            "example": ["Vulnerability_LifeEvents"],
             "nullable": true
           }
         },
@@ -2355,7 +2355,7 @@
             "example": "Friar",
             "pattern": "[^0-9!$%^_=+><?|;~@£&()/\\\\[\\]{}:\",#`¬]{1,255}"
           },
-          "emailAddress": {
+          "email": {
             "type": "string",
             "description": "Customer's email address. Must be RFC compliant.",
             "nullable": true,

--- a/data/endpoints/customers_v2_sole_trader.json
+++ b/data/endpoints/customers_v2_sole_trader.json
@@ -2411,7 +2411,7 @@
             "nullable": true,
             "example": "Agrowicz"
           },
-          "emailAddress": {
+          "email": {
             "type": "string",
             "description": "The customer's email address. Must be RFC compliant.",
             "nullable": true,


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

- Updated error in field name: `emailAddress` to `email`
- Improved field description in `CraRating` field
- Fixed example for array field to display as array