### PR TITLE
GBP Transactions: Add callout for latency between webhooks and endpoint data

### DIFF
--- a/content/uk/docs/gbp-accounts/transaction-data.mdx
+++ b/content/uk/docs/gbp-accounts/transaction-data.mdx
@@ -7,6 +7,7 @@ showPageMenu: true
 
 import EndpointBlock from "src/components/endpoint-block";
 import WebhookPlaceholder from 'src/components/webhook-placeholder'
+import Callout from "src/components/callout";
 
 ## Transaction data
 
@@ -16,6 +17,12 @@ ClearBank allows you to retrieve transactions against:
 - and virtual accounts.
 
 This includes information about payments which have been settled, those that are currently being processed, and those which have been rejected.
+
+To be notified of transactions as soon as they are processed, you should subscribe to the relevant webhooks for each payment rail.
+
+<Callout colour="blue">
+  Our transaction data endpoints are <i>eventually consistent</i>. This means there may be up to a ~200ms delay between when the transaction settled webhook is emitted and when the current transaction data is available from the below endpoints.
+</Callout>
 
 <EndpointBlock
   type="get"

--- a/content/uk/docs/gbp-accounts/transaction-data.mdx
+++ b/content/uk/docs/gbp-accounts/transaction-data.mdx
@@ -21,7 +21,7 @@ This includes information about payments which have been settled, those that are
 To be notified of transactions as soon as they are processed, you should subscribe to the relevant webhooks for each payment rail.
 
 <Callout colour="blue">
-  Our transaction data endpoints are <i>eventually consistent</i>. This means there may be up to a ~200ms delay between when the transaction settled webhook is emitted and when the current transaction data is available from the below endpoints.
+  Our transaction data is <i>eventually consistent</i>: there may be a small delay between when a transaction settled webhook is emitted and when the current transaction data is available via these endpoints. We recommend you implement a retry policy to handle any inconsistency gracefully.
 </Callout>
 
 <EndpointBlock


### PR DESCRIPTION
Added details concerning latency between transaction data and transaction settled webhooks for sterling transactions.