### PR TITLE
SEPA CT mandatory originator address for non-EEA payments

### DIFF
--- a/content/eu/docs/eur-payments/sepa-credit-transfer.mdx
+++ b/content/eu/docs/eur-payments/sepa-credit-transfer.mdx
@@ -55,6 +55,11 @@ If are interested in becoming a SEPA Indirect participant, contact your Client D
 
 To send a payment, use the [POST /payments/sepa-ct/v1/customer-payments](#send-an-sct-outbound-payment) endpoint. You will receive the [SEPA CT Outbound Payment Completed webhook](#sepa-ct-outbound-payment-completed-webhook) and the [Customer Accounts Transaction Completed webhook](#customer-accounts-transaction-completed-webhook).
 
+<Callout colour="blue">
+<p><b>Mandatory originator address for non-EEA payments</b><br />
+To comply with the SEPA scheme rulebook, if the payment originates from outside the <a href="https://european-union.europa.eu/principles-priorities-and-initiatives/eu-countries_en">European Economic Area (EEA)</a> or the beneficiary resides outside the EEA, you must include the originator's <b>town</b> and <b>country</b> address fields in your request. Payments missing these fields will be rejected.</p>
+</Callout>
+
 ![A message flow diagram explaining how to send an SCT payment](/assets/images/sepa-ct-send-payment.svg)
 
 <EndpointBlock

--- a/data/endpoints/sepa-ct-v1.json
+++ b/data/endpoints/sepa-ct-v1.json
@@ -455,7 +455,7 @@
             "example": "NL73ABNA0529451824"
           },
           "postalAddress": {
-            "$ref": "#/components/schemas/PostalAddress"
+            "$ref": "#/components/schemas/DebtorPostalAddress"
           },
           "identification": {
             "$ref": "#/components/schemas/Identification"
@@ -599,6 +599,68 @@
             "pattern": "[A-Z]{2,2}",
             "type": "string",
             "description": "Nation with its own government.",
+            "example": "GB"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DebtorPostalAddress": {
+        "required": [
+          "country",
+          "townName"
+        ],
+        "type": "object",
+        "description": "Postal address of the debtor. townName and country are mandatory if the payment originates from or is destined for a country outside the EEA.",
+        "properties": {
+          "streetName": {
+            "maxLength": 70,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]((?!//)([0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+/ ]))+[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]$",
+            "type": "string",
+            "description": "Name of a street or thoroughfare.",
+            "example": "My Street"
+          },
+          "buildingNumber": {
+            "maxLength": 16,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]((?!//)([0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+/ ]))+[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]$",
+            "type": "string",
+            "description": "Number that identifies the position of a building on a street.",
+            "nullable": true,
+            "example": "1"
+          },
+          "townName": {
+            "maxLength": 35,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]((?!//)([0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+/ ]))+[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]$",
+            "type": "string",
+            "description": "Name of a built-up area, with defined boundaries, and a local government. Mandatory if the payment origin or destination country is outside the EEA.",
+            "nullable": true,
+            "example": "London"
+          },
+          "postCode": {
+            "maxLength": 16,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]((?!//)([0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+/ ]))+[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]$",
+            "type": "string",
+            "description": "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail.",
+            "nullable": true,
+            "example": "XX99 9XX"
+          },
+          "countrySubdivision": {
+            "maxLength": 35,
+            "minLength": 1,
+            "pattern": "^[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]((?!//)([0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+/ ]))+[0-9a-zA-Z\\-\\?:\\(\\)\\.,'\\+]$",
+            "type": "string",
+            "description": "Identifies a subdivision of a country such as state, region, county.",
+            "nullable": true,
+            "example": "London"
+          },
+          "country": {
+            "minLength": 1,
+            "pattern": "[A-Z]{2,2}",
+            "type": "string",
+            "description": "Nation with its own government. Mandatory if the payment origin or destination country is outside the EEA.",
             "example": "GB"
           }
         },


### PR DESCRIPTION
- Update to send a SEPA CT payment where if the payment originates outside the EEA, or the beneficiary resides outside the EEA, you must now include the beneficiary's town and address to align with SEPA scheme rules