### PR TITLE
Timing requirements for Bank of England pacs.009 defunding payments

### DIFF
--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -139,7 +139,7 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 ### Pacs.009 defund payment timing
 If you are a Reserve Account Holder (RAH) and use BERTI to set up future-dated or future-timed pacs.009 defund payments from your Bank of England Reserve Account to your ClearBank account, you must specify a payment time no earlier than **06:00**.
   
-If no time is specified, the payment defaults to when the Bank of England system opens. After a an industry release, this may be before 06:00. In alignment with Bank of England rules, CHAPS BAU (Business as Usual) traffic must not be sent before 06:00.
+If no time is specified, the payment defaults to when the Bank of England system opens. After an industry release, this may be before 06:00. In alignment with Bank of England rules, CHAPS BAU (Business as Usual) traffic must not be sent before 06:00.
 
 **Please note:** This only applies to payments initiated by you in the Bank of England system and sent to your ClearBank account (defunding scenario). There is no impact to outbound CHAPS pacs.009 payments sent from ClearBank.
 

--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -136,6 +136,14 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 |Business	|OrganisationIdentifier	| Registered business name |
 |Financial institution	|OrganisationIdentifier	| Institution name (if acting as creditor)|
 
+### Pacs.009 defund payment timing
+If you are a Reserve Account Holder (RAH) and use BERTI to set up future-dated or future-timed pacs.009 defund payments from your Bank of England Reserve Account to your ClearBank account, you must specify a payment time no earlier than **06:00**.
+  
+If no time is specified, the payment defaults to when the Bank of England system opens. During Controlled Start and Monitored Start procedures, this may be before 06:00. In alignment with Bank of England rules, CHAPS BAU (Business as Usual) traffic must not be sent before 06:00.
+
+**Please note:** This only applies to payments initiated by you in the Bank of England system and sent to your ClearBank account (defunding scenario). There is no impact to outbound CHAPS pacs.009 payments sent from ClearBank.
+
+
 <EndpointBlock
     type="post"
     title="Send a CHAPS payment"

--- a/content/uk/docs/gbp-payments/chaps.mdx
+++ b/content/uk/docs/gbp-payments/chaps.mdx
@@ -139,7 +139,7 @@ Depending on the creditor type, you will need to populate either the `PrivateIde
 ### Pacs.009 defund payment timing
 If you are a Reserve Account Holder (RAH) and use BERTI to set up future-dated or future-timed pacs.009 defund payments from your Bank of England Reserve Account to your ClearBank account, you must specify a payment time no earlier than **06:00**.
   
-If no time is specified, the payment defaults to when the Bank of England system opens. During Controlled Start and Monitored Start procedures, this may be before 06:00. In alignment with Bank of England rules, CHAPS BAU (Business as Usual) traffic must not be sent before 06:00.
+If no time is specified, the payment defaults to when the Bank of England system opens. After a an industry release, this may be before 06:00. In alignment with Bank of England rules, CHAPS BAU (Business as Usual) traffic must not be sent before 06:00.
 
 **Please note:** This only applies to payments initiated by you in the Bank of England system and sent to your ClearBank account (defunding scenario). There is no impact to outbound CHAPS pacs.009 payments sent from ClearBank.
 


### PR DESCRIPTION
Update to documentation only, no change to API functionality.

- Updated information on timing requirements for pacs.009 Bank of England defunding payments