### PR TITLE
FX RFQ: Update CAD pair trade size limits

### DIFF
--- a/content/uk/docs/multi-currency/fx-trade-rfq.mdx
+++ b/content/uk/docs/multi-currency/fx-trade-rfq.mdx
@@ -123,7 +123,7 @@ Each FX currency pair has a defined maximum trade size per request. If you reque
 
 | Currency pair | Maximum trade size |
 | ------------- | ------------------ |
-| EUR/CAD       | 15,000,000 EUR     |
+| EUR/CAD       | 20,000,000 EUR     |
 | EUR/CHF       | 5,000,000 EUR      |
 | EUR/DKK       | 5,000,000 EUR      |
 | EUR/GBP       | 15,000,000 EUR     |
@@ -136,7 +136,7 @@ Each FX currency pair has a defined maximum trade size per request. If you reque
 | GBP/NOK       | 5,000,000 GBP      |
 | GBP/SEK       | 5,000,000 GBP      |
 | GBP/USD       | 10,000,000 GBP     |
-| USD/CAD       | 15,000,000 USD     |
+| USD/CAD       | 20,000,000 USD     |
 | USD/CHF       | 5,000,000 USD      |
 | USD/DKK       | 5,000,000 USD      |
 | USD/NOK       | 5,000,000 USD      |


### PR DESCRIPTION
Updated trade size limits for two currency pairs:

- EUR/CAD 15,000,000 -> 20,000,000
- USD/CAD 15,000,000 -> 20,000,000