### PR TITLE
Docs fix: update example value

### DIFF
--- a/data/endpoints/mccy-payments-v1.json
+++ b/data/endpoints/mccy-payments-v1.json
@@ -776,7 +776,7 @@
                 "maxLength": 11,
                 "pattern": "[A-Z0-9]{4,4}[A-Z]{2,2}[A-Z0-9]{2,2}([A-Z0-9]{3,3}){0,1}",
                 "nullable": true,
-                "example": "NL91CBNL0215162201"
+                "example": "NWBKGB2LXXX"
               },
               "aba": {
                 "type": "string",


### PR DESCRIPTION
Documentation update only; no change to API functionality.

Corrected example BIC value (was an IBAN) for an MCCY endpoint.