### PR TITLE
Simulating held payments info

### DIFF
--- a/webhooks/outbound-held-transaction-v1.mdx
+++ b/webhooks/outbound-held-transaction-v1.mdx
@@ -13,7 +13,13 @@ You will not have access to funds associated with a held transaction until a dec
 * If we release a held transaction, the Transaction Settled webhook is raised.  
 * If we decline a held transaction, funds associated with the held transaction are returned to you and the Transaction Rejected webhook with the CancellationCode of HOPRJ is raised.
 
-To simulate an Outbound Transaction Held webhook in the sim environment, send a Faster Payment using the [POST /v3/payments/fps](../gbp-payments/faster-payments#send-faster-payments) endpoint with the `Name` field of the `Creditor` object set to `6a41a29eafcf455493`.
+| Payment rail      | Simulate Outbound Transaction Held webhook |
+| ----------- |  ----------- |
+| Faster Payments | Use [POST /v3/payments/fps](../gbp-payments/faster-payments#send-faster-payments), with `Name` field of the `Creditor` object set to `6a41a29eafcf455493` |
+| CHAPS pacs.008 | Use [POST /payments/chaps/v6/customer-payments](../gbp-payments/chaps#send-a-chaps-payment), with `Name` field of the `Creditor` object set to `6a41a29eafcf455493` |
+| CHAPS pacs.009 | Use [POST /payments/chaps/v6/institution-payments](../gbp-payments/chaps#send-a-chaps-bank-to-bank-payment), with `Name` field of the `Creditor` object set to `6a41a29eafcf455493` |
+| GBP Cross-Border | Use [POST /payments/cross-border-sterling/v4/payments](../gbp-payments/gbp-cross-border#send-a-gbp-cross-border-payment), with `remittanceInformation` field set to `TSCHOLDESCALATE`. |
+
 
 #### Request body
 


### PR DESCRIPTION
Update to documentation only. No change to API functionality.

Explanation on how to generate simulation Outbound Held Transaction webhook for CHAPS and GBP Cross-Border.