### PR TITLE
MCCY v1: update addressLine2 descriptions and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/endpoints.json
 data/webhooks.json
 
 .idea/
+.agents
 
 # Secrets
 secret.auto.tfvars

--- a/data/endpoints/mccy-payments-v1.json
+++ b/data/endpoints/mccy-payments-v1.json
@@ -489,14 +489,14 @@
                 "minLength": 1,
                 "maxLength": 70,
                 "description": "First line of the creditor's address.",
-                "example": "123A"
+                "example": "123A, Long road"
               },
               "addressLine2": {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 35,
-                "description": "Second line of the creditor's address.",
-                "example": "Wren Way"
+                "description": "Second line of the creditor's address. From 30 October 2026, this must be the town name of the address.",
+                "example": "Chaffinch Town"
               },
               "addressLine3": {
                 "type": "string",
@@ -504,7 +504,7 @@
                 "maxLength": 35,
                 "description": "Third line of the creditor's address.",
                 "nullable": true,
-                "example": "Hamlinton"
+                "example": "Hamlinshire"
               },
               "postCode": {
                 "type": "string",
@@ -808,15 +808,15 @@
                     "maxLength": 70,
                     "description": "First line of the intermediary agent's address.",
                     "nullable": true,
-                    "example": "12 Banking Building"
+                    "example": "12 Banking Building, Bank Street"
                   },
                   "addressLine2": {
                     "type": "string",
                     "minLength": 0,
                     "maxLength": 35,
-                    "description": "Second line of the intermediary agent's address.",
+                    "description": "Second line of the intermediary agent's address. From 30 October 2026, this must be the town name of the address.",
                     "nullable": true,
-                    "example": "Bank Street"
+                    "example": "Finance Town"
                   },
                   "addressLine3": {
                     "type": "string",
@@ -824,7 +824,7 @@
                     "maxLength": 35,
                     "description": "Third line of the intermediary agent's address.",
                     "nullable": true,
-                    "example": "Belfast"
+                    "example": "County Down"
                   },
                   "postCode": {
                     "type": "string",
@@ -918,15 +918,15 @@
                     "maxLength": 70,
                     "description": "First line of the creditor agent's address.",
                     "nullable": true,
-                    "example": "11 The Square"
+                    "example": "11 The Square, Circle Lane"
                   },
                   "addressLine2": {
                     "type": "string",
                     "minLength": 0,
                     "maxLength": 35,
-                    "description": "Second line of the creditor agent's address.",
+                    "description": "Second line of the creditor agent's address. From 30 October 2026, this must be the town name of the address.",
                     "nullable": true,
-                    "example": "Circle District"
+                    "example": "Triangle Town"
                   },
                   "addressLine3": {
                     "type": "string",
@@ -934,7 +934,7 @@
                     "maxLength": 35,
                     "description": "Third line of the creditor agent's address.",
                     "nullable": true,
-                    "example": "Sphere City"
+                    "example": "Sphere County"
                   },
                   "postCode": {
                     "type": "string",
@@ -948,7 +948,7 @@
                     "minLength": 2,
                     "maxLength": 2,
                     "type": "string",
-                    "description": "Two-letter ISO country code for the creditor agent's address. Mandatory only when the creditor agent's details are being provided.",
+                    "description": "Two-letter ISO 3166 country code for the creditor agent's address. Mandatory only when the creditor agent's details are being provided.",
                     "pattern": "^[A-Z]{2}$",
                     "example": "GB"
                   }
@@ -1038,15 +1038,15 @@
                 "maxLength": 70,
                 "description": "First line of the ultimate creditor's address.",
                 "nullable": true,
-                "example": "21 Cyan"
+                "example": "21 Cyan Avenue"
               },
               "addressLine2": {
                 "type": "string",
                 "minLength": 0,
                 "maxLength": 35,
-                "description": "Second line of the ultimate creditor's address.",
+                "description": "Second line of the ultimate creditor's address. From 30 October 2026, this must be the town name of the address.",
                 "nullable": true,
-                "example": "Fontainebleau"
+                "example": "Rosetown"
               },
               "addressLine3": {
                 "type": "string",
@@ -1054,7 +1054,7 @@
                 "maxLength": 35,
                 "description": "Third line of the ultimate creditor's address.",
                 "nullable": true,
-                "example": "Île-de-France"
+                "example": "Countyshire"
               },
               "postCode": {
                 "type": "string",
@@ -1279,14 +1279,14 @@
                 "minLength": 1,
                 "maxLength": 70,
                 "description": "First line of the debtor's address.",
-                "example": "Green House"
+                "example": "Green House, Purple Lane"
               },
               "addressLine2": {
                 "type": "string",
                 "minLength": 1,
                 "maxLength": 35,
-                "description": "Second line of the debtor's address.",
-                "example": "Purple Lane"
+                "description": "Second line of the debtor's address. From 30 October 2026, this must be the town name of the address.",
+                "example": "Blue Town"
               },
               "addressLine3": {
                 "type": "string",
@@ -1294,7 +1294,7 @@
                 "maxLength": 35,
                 "description": "Third line of the debtor's address.",
                 "nullable": true,
-                "example": "Orange District"
+                "example": "Orange County"
               },
               "postCode": {
                 "type": "string",
@@ -1352,7 +1352,7 @@
                     "maxLength": 2,
                     "pattern": "^[A-Z]{2}$",
                     "nullable": true,
-                    "example": "France"
+                    "example": "FR"
                   }
                 }
               },

--- a/data/endpoints/mccy-payments-v1.json
+++ b/data/endpoints/mccy-payments-v1.json
@@ -517,7 +517,7 @@
                 "minLength": 2,
                 "maxLength": 2,
                 "type": "string",
-                "description": "Two-letter ISO country code for the creditor's address.",
+                "description": "Two-letter ISO-3166 country code for the creditor's address.",
                 "pattern": "^[A-Z]{2}$",
                 "example": "PT"
               }
@@ -610,7 +610,7 @@
                       },
                       "countryOfBirth": {
                         "type": "string",
-                        "description": "Two-letter ISO country code for the creditor's country of birth.",
+                        "description": "Two-letter ISO-3166 country code for the creditor's country of birth.",
                         "minLength": 0,
                         "maxLength": 2,
                         "pattern": "^[A-Z]{2}$",
@@ -661,7 +661,7 @@
           },
           "countryOfResidence": {
             "type": "string",
-            "description": "Two-letter ISO country code for the creditor's country of residence.",
+            "description": "Two-letter ISO-3166 country code for the creditor's country of residence.",
             "minLength": 0,
             "maxLength": 2,
             "pattern": "^[A-Z]{2}$",
@@ -838,7 +838,7 @@
                     "minLength": 2,
                     "maxLength": 2,
                     "type": "string",
-                    "description": "Two-letter ISO country code for the intermediary agent's address. Mandatory only when the intermediary agent's details are being provided.",
+                    "description": "Two-letter ISO-3166 country code for the intermediary agent's address. Mandatory only when the intermediary agent's details are being provided.",
                     "pattern": "^[A-Z]{2}$",
                     "example": "GB"
                   }
@@ -948,7 +948,7 @@
                     "minLength": 2,
                     "maxLength": 2,
                     "type": "string",
-                    "description": "Two-letter ISO 3166 country code for the creditor agent's address. Mandatory only when the creditor agent's details are being provided.",
+                    "description": "Two-letter ISO-3166 country code for the creditor agent's address. Mandatory only when the creditor agent's details are being provided.",
                     "pattern": "^[A-Z]{2}$",
                     "example": "GB"
                   }
@@ -1068,7 +1068,7 @@
                 "minLength": 2,
                 "maxLength": 2,
                 "type": "string",
-                "description": "Two-letter ISO country code for the ultimate creditor's address. Mandatory only when the ultimate creditor's details are being provided.",
+                "description": "Two-letter ISO-3166 country code for the ultimate creditor's address. Mandatory only when the ultimate creditor's details are being provided.",
                 "pattern": "^[A-Z]{2}$",
                 "example": "FR"
               }
@@ -1164,7 +1164,7 @@
                       },
                       "countryOfBirth": {
                         "type": "string",
-                        "description": "Two-letter ISO country code for the ultimate creditor's country of birth.",
+                        "description": "Two-letter ISO-3166 country code for the ultimate creditor's country of birth.",
                         "minLength": 0,
                         "maxLength": 2,
                         "pattern": "^[A-Z]{2}$",
@@ -1307,7 +1307,7 @@
                 "minLength": 2,
                 "maxLength": 2,
                 "type": "string",
-                "description": "Two-letter ISO country code for the debtor's address.",
+                "description": "Two-letter ISO-3166 country code for the debtor's address.",
                 "pattern": "^[A-Z]{2}$",
                 "example": "GB"
               }
@@ -1347,7 +1347,7 @@
                   },
                   "countryOfBirth": {
                     "type": "string",
-                    "description": "Two-letter ISO country code for the debtor's country of birth.",
+                    "description": "Two-letter ISO-3166 country code for the debtor's country of birth.",
                     "minLength": 0,
                     "maxLength": 2,
                     "pattern": "^[A-Z]{2}$",


### PR DESCRIPTION
Documentation update only; no change to API functionality.

Amended descriptions of `POST /v1/mccy/payments` endpoint to warn of an upcoming validation requirement:
- updated descriptions for addressLine2
- updated example values for address objects
- clarified ISO-3166 for countryCodes