### PR TITLE
Docs fix: customers v2 make email mandatory

### DIFF
--- a/data/endpoints/customers_v2_legal_entity.json
+++ b/data/endpoints/customers_v2_legal_entity.json
@@ -1569,7 +1569,8 @@
           "registeredName",
           "registrationNumber",
           "countryOfRegistration",
-          "tradingName"
+          "tradingName",
+          "email"
         ],
         "type": "object",
         "properties": {

--- a/data/endpoints/customers_v2_retail.json
+++ b/data/endpoints/customers_v2_retail.json
@@ -1821,7 +1821,8 @@
           "countryOfResidence",
           "dateOfBirth",
           "firstName",
-          "surname"
+          "surname",
+          "email"
         ],
         "type": "object",
         "properties": {

--- a/data/endpoints/customers_v2_sole_trader.json
+++ b/data/endpoints/customers_v2_sole_trader.json
@@ -1862,7 +1862,8 @@
           "countryOfResidence",
           "dateOfBirth",
           "firstName",
-          "surname"
+          "surname",
+          "email"
         ],
         "type": "object",
         "properties": {


### PR DESCRIPTION
Email address is now a mandatory field for Sole Traders, Retail customers, and Legal Entities on their respective creation 'POST' requests.